### PR TITLE
Fix client side not to expect 24 bytes connection header

### DIFF
--- a/example/client.rb
+++ b/example/client.rb
@@ -7,6 +7,7 @@ Addrinfo.tcp("localhost", 8080).connect do |sock|
     sock.print bytes
     sock.flush
   end
+  sock.print HTTP2::CONNECTION_HEADER
 
   stream = conn.new_stream
   log = Logger.new(stream.id)
@@ -30,6 +31,7 @@ Addrinfo.tcp("localhost", 8080).connect do |sock|
 
   puts "Sending POST request"
   stream.headers({
+    ":scheme" => "http",
     ":method" => "post",
     ":host" => "localhost",
     ":path" => "/resource",

--- a/lib/http/2/connection.rb
+++ b/lib/http/2/connection.rb
@@ -69,10 +69,12 @@ module HTTP2
         @stream_id    = 2
         @compressor   = Header::Compressor.new(:response)
         @decompressor = Header::Decompressor.new(:request)
+        @state = :new
       else
         @stream_id    = 1
         @compressor   = Header::Compressor.new(:request)
         @decompressor = Header::Decompressor.new(:response)
+        @state = :connection_header
       end
 
       @stream_limit = Float::INFINITY
@@ -86,7 +88,6 @@ module HTTP2
       @recv_buffer = Buffer.new
       @send_buffer = []
       @continuation = []
-      @state = :new
       @error = nil
     end
 

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -96,7 +96,7 @@ FRAME_TYPES = [
 
 def new_connection(type = :client)
   conn = Connection.new(type)
-  conn << CONNECTION_HEADER
+  conn << CONNECTION_HEADER if type == :server
   conn
 end
 


### PR DESCRIPTION
This commit fixes client side code so that it does not expect 24
bytes connection header.

This is because the client connection header is 24 bytes
connection header followed by SETTINGS frame. On the other hand,
the server connection header is SETTINGS frame only.

example/client.rb now sends 24 bytes connection header and also
sends :scheme header field, which is required by the
specification.
