### PR TITLE
Update 'once' listeners to accept a block argument

### DIFF
--- a/lib/http/2/emitter.rb
+++ b/lib/http/2/emitter.rb
@@ -20,8 +20,8 @@ module HTTP2
     # @param event [Symbol]
     # @param block [Proc] callback function
     def once(event, &block)
-      add_listener(event) do |*args|
-        block.call(*args)
+      add_listener(event) do |*args, &callback|
+        block.call(*args, &callback)
         :delete
       end
     end

--- a/spec/emitter_spec.rb
+++ b/spec/emitter_spec.rb
@@ -31,6 +31,14 @@ describe HTTP2::Emitter do
     args.should eq 123
   end
 
+  it "should pass emitted callbacks to listeners" do
+    @w.on(:a)   { |&block| block.call }
+    @w.once(:a) { |&block| block.call }
+    @w.emit(:a) { @cnt += 1 }
+
+    @cnt.should eq 2
+  end
+
   it "should allow events with no callbacks" do
     expect { @w.emit(:missing) }.to_not raise_error
   end


### PR DESCRIPTION
One-time listeners can now accept an emitted callback to match the behavior of persistent listeners. This appears to be the intended behavior based on this [change](https://github.com/igrigorik/http-2/commit/cd108d723dfd6d6cf475f545b4220e5022d6299a#diff-890759efb7afe0816c5f7c678dd89ab6R36).
