### PR TITLE
add settings acknowledgement

### DIFF
--- a/lib/http/2/client.rb
+++ b/lib/http/2/client.rb
@@ -25,6 +25,7 @@ module HTTP2
       @state        = :connection_header
       @compressor   = Header::Compressor.new(:request)
       @decompressor = Header::Decompressor.new(:response)
+      @prefaced     = false
 
       super
     end
@@ -36,7 +37,8 @@ module HTTP2
     # @note Client will emit the connection header as the first 24 bytes
     # @param frame [Hash]
     def send(frame)
-      if @state == :connection_header
+      if @state == :connection_header && !@prefaced
+        @prefaced = true
         emit(:frame, CONNECTION_HEADER)
         @state = :connected
 

--- a/lib/http/2/framer.rb
+++ b/lib/http/2/framer.rb
@@ -39,7 +39,7 @@ module HTTP2
       },
       priority:     {},
       rst_stream:   {},
-      settings:     {},
+      settings:     { ack: 0 },
       push_promise: { end_push_promise: 0 },
       ping:         { pong: 0 },
       goaway:       {},


### PR DESCRIPTION
This is an incomplete patch, but I'd prefer more peoples' input before progressing with it.

The problems:
1.  It breaks spec -- if client-server communications are immediate and synchronous (as in the "HTTP2::Stream Server API push" specs) we can have a situation where one of them sends a SETTINGS[ACK] before it has a chance to send its own initial SETTINGS.
   
   This really should be fixed, but I'm afraid I'd over-engineer it.
2.  There's a remaining issue of settings synchronization -- we currently assume settings apply as soon as we send them, but maybe we should set up a local-settings queue so we only actually apply them on receiving the ACK.

As it is, the relevant specs pass and it shouldn't have any interop problems with compliant peers.

Contributes to #11 
