### PR TITLE
Unify request/response roles of Compressor/Decompressor

### DIFF
--- a/lib/http/2/client.rb
+++ b/lib/http/2/client.rb
@@ -20,11 +20,9 @@ module HTTP2
   class Client < Connection
 
     # Initialize new HTTP 2.0 client object.
-    def initialize(*args)
+    def initialize(**settings)
       @stream_id    = 1
       @state        = :connection_header
-      @compressor   = Header::Compressor.new(:request)
-      @decompressor = Header::Decompressor.new(:response)
 
       super
     end

--- a/lib/http/2/connection.rb
+++ b/lib/http/2/connection.rb
@@ -40,8 +40,12 @@ module HTTP2
 
     # Initializes new connection object.
     #
-    def initialize(streams: 100, window: DEFAULT_FLOW_WINDOW)
+    def initialize(streams: 100, window: DEFAULT_FLOW_WINDOW, **settings)
       @stream_limit = streams
+
+      @compressor   = Header::Compressor.new(settings)
+      @decompressor = Header::Decompressor.new(settings)
+
       @active_stream_count = 0
       @streams = {}
 

--- a/lib/http/2/server.rb
+++ b/lib/http/2/server.rb
@@ -22,11 +22,9 @@ module HTTP2
   class Server < Connection
 
     # Initialize new HTTP 2.0 server object.
-    def initialize(*args)
+    def initialize(**settings)
       @stream_id    = 2
       @state        = :new
-      @compressor   = Header::Compressor.new(:response)
-      @decompressor = Header::Decompressor.new(:request)
 
       super
     end

--- a/spec/connection_spec.rb
+++ b/spec/connection_spec.rb
@@ -175,7 +175,7 @@ describe HTTP2::Connection do
         ["x-my-header", "first"]
       ]
 
-      cc = Compressor.new(:response)
+      cc = Compressor.new
       headers = HEADERS.dup
       headers[:payload] = cc.encode(req_headers)
 
@@ -195,7 +195,7 @@ describe HTTP2::Connection do
         ["x-my-header", "first"]
       ]
 
-      cc = Compressor.new(:response)
+      cc = Compressor.new
       h1, h2 = HEADERS.dup, CONTINUATION.dup
       h1[:payload] = cc.encode([req_headers.first])
       h1[:stream] = 5

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -34,14 +34,14 @@ HEADERS = {
   type: :headers,
   flags: [:end_headers],
   stream: 1,
-  payload: Compressor.new(:request).encode([['a','b']])
+  payload: Compressor.new.encode([['a','b']])
 }
 
 HEADERS_END_STREAM = {
   type: :headers,
   flags: [:end_headers, :end_stream],
   stream: 1,
-  payload: Compressor.new(:request).encode([['a','b']])
+  payload: Compressor.new.encode([['a','b']])
 }
 
 PRIORITY = {
@@ -70,7 +70,7 @@ PUSH_PROMISE = {
   flags: [:end_headers],
   stream: 1,
   promise_stream: 2,
-  payload: Compressor.new(:request).encode([['a','b']])
+  payload: Compressor.new.encode([['a','b']])
 }
 
 PING = {

--- a/spec/hpack_test_spec.rb
+++ b/spec/hpack_test_spec.rb
@@ -32,7 +32,7 @@ describe HTTP2::Header do
             cases = story['cases']
             table_size = cases[0]['header_table_size'] || 4096
             context = story['context'] ? story['context'].to_sym : :request
-            @dc = Decompressor.new(context, table_size: table_size)
+            @dc = Decompressor.new(table_size: table_size)
             cases.each do |c|
               wire = [c['wire']].pack("H*").force_encoding('binary')
               @emitted = @dc.decode(HTTP2::Buffer.new(wire))
@@ -64,8 +64,8 @@ describe HTTP2::Header do
                 story = JSON.parse(File.read("#{path}/#{file}"))
                 cases = story['cases']
                 context = story['context'] ? story['context'].to_sym : :request
-                @cc = Compressor  .new(context, table_size: table_size)
-                @dc = Decompressor.new(context, table_size: table_size)
+                @cc = Compressor  .new(table_size: table_size)
+                @dc = Decompressor.new(table_size: table_size)
                 cases.each do |c|
                   headers = c['headers'].flat_map(&:to_a)
                   wire = @cc.encode(headers)


### PR DESCRIPTION
Latest HPACK spec has no distinction between request and response.
