### PR TITLE
jruby 9k released

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: ruby
 rvm:
   - 2.1
   - 2.2
-  - jruby-9.0.0.0.pre2
+  - jruby-9.0.0.0
   - jruby-head
   - rbx-2
 matrix:


### PR DESCRIPTION
since jruby 9k out modified the travis to check http-2 is compatible with the latest ruby version.