### PR TITLE
Fixes sending of rst_stream

### DIFF
--- a/lib/http/2/connection.rb
+++ b/lib/http/2/connection.rb
@@ -342,7 +342,12 @@ module HTTP2
         # An endpoint can end a connection at any time. In particular, an
         # endpoint MAY choose to treat a stream error as a connection error.
         if frame[:type] == :rst_stream
-          goaway(frame[:error]) if frame[:error] == :protocol_error
+          if frame[:error] == :protocol_error
+            goaway(frame[:error])
+          else
+            frames = encode(frame)
+            frames.each {|f| emit(:frame, f) }
+          end
         else
           # HEADERS and PUSH_PROMISE may generate CONTINUATION
           frames = encode(frame)

--- a/lib/http/2/connection.rb
+++ b/lib/http/2/connection.rb
@@ -341,15 +341,11 @@ module HTTP2
       else
         # An endpoint can end a connection at any time. In particular, an
         # endpoint MAY choose to treat a stream error as a connection error.
-        if frame[:type] == :rst_stream
-          if frame[:error] == :protocol_error
-            goaway(frame[:error])
-          else
-            frames = encode(frame)
-            frames.each {|f| emit(:frame, f) }
-          end
+        if frame[:type] == :rst_stream && frame[:error] == :protocol_error
+          goaway(frame[:error])
         else
-          # HEADERS and PUSH_PROMISE may generate CONTINUATION
+          # HEADERS and PUSH_PROMISE may generate CONTINUATION. Also send
+          # RST_STREAM that are not protocol errors
           frames = encode(frame)
           frames.each { |f| emit(:frame, f) }
         end

--- a/lib/http/2/error.rb
+++ b/lib/http/2/error.rb
@@ -25,7 +25,7 @@ module HTTP2
 
     # Raised on invalid stream processing: invalid frame type received or
     # sent, or invalid command issued.
-    class StreamError < ProtocolError; end
+    class InternalError < ProtocolError; end
 
     #
     # -- Recoverable errors -------------------------------------------------

--- a/lib/http/2/stream.rb
+++ b/lib/http/2/stream.rb
@@ -566,7 +566,7 @@ module HTTP2
       end
     end
 
-    def stream_error(error = :stream_error, msg: nil)
+    def stream_error(error = :internal_error, msg: nil)
       @error = error
       close(error) if @state != :closed
 

--- a/spec/stream_spec.rb
+++ b/spec/stream_spec.rb
@@ -56,13 +56,15 @@ RSpec.describe HTTP2::Stream do
 
       it 'should raise error if sending invalid frames' do
         (FRAME_TYPES - [HEADERS, RST_STREAM]).each do |type|
-          expect { @stream.dup.send type }.to raise_error StreamError
+          expect { @stream.dup.send type }.to raise_error InternalError
         end
       end
 
       it 'should raise error on receipt of invalid frames' do
-        (FRAME_TYPES - [PRIORITY, RST_STREAM, WINDOW_UPDATE]).each do |type|
-          expect { @stream.dup.receive type }.to raise_error StreamError
+        what_types = (FRAME_TYPES - [PRIORITY, RST_STREAM, WINDOW_UPDATE])
+        what_types.each do |type|
+          p "test type #{type}"
+          expect { @stream.dup.receive type }.to raise_error InternalError
         end
       end
 
@@ -101,13 +103,13 @@ RSpec.describe HTTP2::Stream do
 
       it 'should raise error if sending invalid frames' do
         (FRAME_TYPES - [PRIORITY, RST_STREAM, WINDOW_UPDATE]).each do |type|
-          expect { @stream.dup.send type }.to raise_error StreamError
+          expect { @stream.dup.send type }.to raise_error InternalError
         end
       end
 
       it 'should raise error on receipt of invalid frames' do
         (FRAME_TYPES - [HEADERS, RST_STREAM]).each do |type|
-          expect { @stream.dup.receive type }.to raise_error StreamError
+          expect { @stream.dup.receive type }.to raise_error InternalError
         end
       end
 
@@ -283,7 +285,7 @@ RSpec.describe HTTP2::Stream do
 
       it 'should raise error on attempt to send invalid frames' do
         (FRAME_TYPES - [PRIORITY, RST_STREAM, WINDOW_UPDATE]).each do |frame|
-          expect { @stream.dup.send frame }.to raise_error StreamError
+          expect { @stream.dup.send frame }.to raise_error InternalError
         end
       end
 
@@ -303,7 +305,7 @@ RSpec.describe HTTP2::Stream do
       end
 
       it 'should transition to closed if RST_STREAM frame is sent' do
-        @stream.send RST_STREAM
+        @stream.send RST_STREAM.deep_dup
         expect(@stream.state).to eq :closed
       end
 
@@ -454,7 +456,7 @@ RSpec.describe HTTP2::Stream do
 
         it 'should allow PRIORITY, RST_STREAM to be sent' do
           expect { @stream.send PRIORITY.dup }.to_not raise_error
-          expect { @stream.send RST_STREAM }.to_not raise_error
+          expect { @stream.send RST_STREAM.dup }.to_not raise_error
         end
 
         it 'should allow PRIORITY, RST_STREAM to be received' do
@@ -480,7 +482,7 @@ RSpec.describe HTTP2::Stream do
       context 'local closed via RST_STREAM frame' do
         before(:each) do
           @stream.send HEADERS.deep_dup     # open
-          @stream.send RST_STREAM  # closed by local
+          @stream.send RST_STREAM.deep_dup  # closed by local
         end
 
         it 'should ignore received frames' do
@@ -588,7 +590,7 @@ RSpec.describe HTTP2::Stream do
       srv = Server.new
       stream = srv.new_stream
 
-      expect { stream.reprioritize(weight: 10) }.to raise_error(StreamError)
+      expect { stream.reprioritize(weight: 10) }.to raise_error(InternalError)
     end
 
     it '.headers should emit HEADERS frames' do


### PR DESCRIPTION
- rst_stream was not being sent unless there was a protocol error
- tests were broken by this change:
  * so fixed the broken tests by renaming StreamError -> InternalError
  * This was necessary because
    + stream#stream_error defaulted to calling close with :stream_error
    + :stream_error is not a DEFINED_ERROR, and could not be converted
      into a valid exception class