### PR TITLE
Corrects #37.

### DIFF
--- a/lib/http/2/stream.rb
+++ b/lib/http/2/stream.rb
@@ -173,16 +173,15 @@ module HTTP2
     # @param payload [String]
     # @param end_stream [Boolean] indicates last response DATA frame
     def data(payload, end_stream: true)
-      flags = []
-
       # Split data according to each frame is smaller enough
       # TODO: consider padding?
       max_size = @connection.remote_settings[:settings_max_frame_size]
       while payload.bytesize > max_size
         chunk = payload.slice!(0, max_size)
-        send(type: :data, flags: flags, payload: chunk)
+        send(type: :data, flags: [], payload: chunk)
       end
 
+      flags = []
       flags << :end_stream if end_stream
       send(type: :data, flags: flags, payload: payload)
     end


### PR DESCRIPTION
The reference to the flags array that will be shared between successive chunks (before they are actually emitted); this can cause streams to terminate early.