### PR TITLE
Exclude bin/* from Rubocop 

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,8 @@ inherit_from: .rubocop_todo.yml
 
 AllCops:
   DisplayCopNames: true
+  Exclude:
+    - 'bin/*'
 
 Lint/EndAlignment:
   AlignWith: variable


### PR DESCRIPTION
... because they are generated by `bundle install` and generate a lot of offences.