### PR TITLE
Add nils to initialize to prevent syntax error

### DIFF
--- a/lib/http/2/stream.rb
+++ b/lib/http/2/stream.rb
@@ -71,7 +71,7 @@ module HTTP2
     # @param exclusive [Boolean]
     # @param window [Integer]
     # @param parent [Stream]
-    def initialize(connection:, id:, weight: 16, dependency: 0, exclusive: false, parent: nil)
+    def initialize(connection: nil, id: nil, weight: 16, dependency: 0, exclusive: false, parent: nil)
       @connection = connection
       @id = id
       @weight = weight


### PR DESCRIPTION
There seems to be an issue with 0.8.0 where you can't initialize a stream. I think it's a simple syntax error and this fixed it.