### PR TITLE
[client] Be sure to send the preface if receiving data first.

### DIFF
--- a/lib/http/2/client.rb
+++ b/lib/http/2/client.rb
@@ -34,13 +34,23 @@ module HTTP2
     # @see Connection
     # @param frame [Hash]
     def send(frame)
-      send_connection_preface
+      if @state == :waiting_connection_preface
+        send_connection_preface
+      end
       super(frame)
+    end
+
+    def connection_management(frame)
+      if @state == :waiting_connection_preface
+        send_connection_preface
+        connection_settings(frame)
+      else
+        super(frame)
+      end
     end
 
     # Emit the connection preface if not yet
     def send_connection_preface
-      return unless @state == :waiting_connection_preface
       @state = :connected
       emit(:frame, CONNECTION_PREFACE_MAGIC)
 


### PR DESCRIPTION
I’m very new to HTTP/2 and this library, so I’m mostly looking for guidance as to why this is needed and where to make the changes in the codebase.

I’m using this lib to connect to Apple’s new Push Notification service. Without this change it would complain about missing a client preface and instead receiving other data (which were settings). What would happen is that the server would send data before I would send any, which would change the `@state` to connected and thus the preface would never get send from `Client#send`.