### PR TITLE
[Buffer] Ensure data added is binary encoded.

### DIFF
--- a/lib/http/2/buffer.rb
+++ b/lib/http/2/buffer.rb
@@ -30,5 +30,13 @@ module HTTP2
     def read_uint32
       read(4).unpack(UINT32).first
     end
+
+    # Ensures that data that is added is binary encoded as well,
+    # otherwise this could lead to the Buffer instance changing its encoding.
+    [:<<, :prepend].each do |mutating_method|
+      define_method(mutating_method) do |string|
+        super(string.force_encoding(Encoding::BINARY))
+      end
+    end
   end
 end

--- a/spec/buffer_spec.rb
+++ b/spec/buffer_spec.rb
@@ -7,6 +7,13 @@ RSpec.describe HTTP2::Buffer do
     expect(b.encoding.to_s).to eq 'ASCII-8BIT'
   end
 
+  it 'should force 8-bit encoding when adding data' do
+    b << 'émalgré'
+    expect(b.encoding.to_s).to eq 'ASCII-8BIT'
+    b.prepend('émalgré')
+    expect(b.encoding.to_s).to eq 'ASCII-8BIT'
+  end
+
   it 'should return bytesize of the buffer' do
     expect(b.size).to eq 9
   end


### PR DESCRIPTION
Without this patch, it was possible for a buffer to change its encoding, which was occurring for me when in `Framer#generate` when [adding data](https://github.com/igrigorik/http-2/blob/v0.8.0/lib/http/2/framer.rb#L185) and then leading to an exception when [prepending the common header](https://github.com/igrigorik/http-2/blob/v0.8.0/lib/http/2/framer.rb#L316).

```
irb(main):001:0> buffer = "".force_encoding(Encoding::BINARY)
=> ""
irb(main):002:0> buffer.encoding
=> #<Encoding:ASCII-8BIT>
irb(main):003:0> buffer << "émalgé"
=> "émalgé"
irb(main):004:0> buffer.encoding
=> #<Encoding:UTF-8>
irb(main):005:0> x = "\x00\x00\x80\x00\x01\x00\x00\x00\x13".force_encoding(Encoding::BINARY)
=> "\x00\x00\x80\x00\x01\x00\x00\x00\x13"
irb(main):006:0> buffer.prepend(x)
Encoding::CompatibilityError: incompatible character encodings: UTF-8 and ASCII-8BIT
	from (irb):6:in `prepend'
	from (irb):6
	from /Users/eloy/.rubies/ruby-2.2.2/bin/irb:11:in `<main>'
```

----

This patch ensures that the mutating methods that are used in `Framer#generate` are guaranteed to have a binary encoding, _but_ it still feels a bit fragile. I think it would be better if `Buffer` were not a `String` subclass, but rather wrap a string and only expose the mutating API needed so that the possible surface for things to go wrong stays controllable. What are your thoughts?