### PR TITLE
fix 'Encoding::CompatibilityError: incompatible character encodings: UTF-8 and ASCII-8BIT' 

### DIFF
--- a/lib/http/2/framer.rb
+++ b/lib/http/2/framer.rb
@@ -147,8 +147,6 @@ module HTTP2
       end
 
       header << frame[:stream]
-      pp "************* common_header function ********************"
-      pp header
       header.pack(HEADERPACK) # 8+16,8,8,32
     end
 

--- a/lib/http/2/framer.rb
+++ b/lib/http/2/framer.rb
@@ -147,6 +147,8 @@ module HTTP2
       end
 
       header << frame[:stream]
+      pp "************* common_header function ********************"
+      pp header
       header.pack(HEADERPACK) # 8+16,8,8,32
     end
 
@@ -313,7 +315,7 @@ module HTTP2
       end
 
       frame[:length] = length
-      bytes.prepend(common_header(frame))
+      bytes.prepend(common_header(frame).force_encoding("UTF-8"))
     end
 
     # Decodes complete HTTP/2 frame from provided buffer. If the buffer


### PR DESCRIPTION
when I use http-2-0.8.0 gem, I got error "Encoding::CompatibilityError: incompatible character encodings: UTF-8 and ASCII-8BIT"
I solved this problem by add [.force_encoding("UTF-8")].
Is this a right solution ?