### PR TITLE
Fix ci

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,6 @@ gem 'rake'
 gem 'yard'
 
 group :test do
-  gem 'activesupport'
   gem 'autotest-standalone'
   gem 'coveralls', require: false
   gem 'pry'

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -1,4 +1,4 @@
-require 'active_support/core_ext/object/deep_dup'
+require './spec/support/deep_dup'
 
 RSpec.configure(&:disable_monkey_patching!)
 RSpec::Expectations.configuration.warn_about_potential_false_positives = false

--- a/spec/support/deep_dup.rb
+++ b/spec/support/deep_dup.rb
@@ -1,0 +1,55 @@
+# https://github.com/rails/rails/blob/master/activesupport/lib/active_support/core_ext/object/deep_dup.rb
+
+require_relative 'duplicable'
+
+class Object
+  # Returns a deep copy of object if it's duplicable. If it's
+  # not duplicable, returns +self+.
+  #
+  #   object = Object.new
+  #   dup    = object.deep_dup
+  #   dup.instance_variable_set(:@a, 1)
+  #
+  #   object.instance_variable_defined?(:@a) # => false
+  #   dup.instance_variable_defined?(:@a)    # => true
+  def deep_dup
+    duplicable? ? dup : self
+  end
+end
+
+class Array
+  # Returns a deep copy of array.
+  #
+  #   array = [1, [2, 3]]
+  #   dup   = array.deep_dup
+  #   dup[1][2] = 4
+  #
+  #   array[1][2] # => nil
+  #   dup[1][2]   # => 4
+  def deep_dup
+    map(&:deep_dup)
+  end
+end
+
+class Hash
+  # Returns a deep copy of hash.
+  #
+  #   hash = { a: { b: 'b' } }
+  #   dup  = hash.deep_dup
+  #   dup[:a][:c] = 'c'
+  #
+  #   hash[:a][:c] # => nil
+  #   dup[:a][:c]  # => "c"
+  def deep_dup
+    hash = dup
+    each_pair do |key, value|
+      if key.frozen? && ::String == key  # changed === to == for rubocop
+        hash[key] = value.deep_dup
+      else
+        hash.delete(key)
+        hash[key.deep_dup] = value.deep_dup
+      end
+    end
+    hash
+  end
+end

--- a/spec/support/duplicable.rb
+++ b/spec/support/duplicable.rb
@@ -1,0 +1,98 @@
+#--
+# Most objects are cloneable, but not all. For example you can't dup +nil+:
+#
+#   nil.dup # => TypeError: can't dup NilClass
+#
+# Classes may signal their instances are not duplicable removing +dup+/+clone+
+# or raising exceptions from them. So, to dup an arbitrary object you normally
+# use an optimistic approach and are ready to catch an exception, say:
+#
+#   arbitrary_object.dup rescue object
+#
+# Rails dups objects in a few critical spots where they are not that arbitrary.
+# That rescue is very expensive (like 40 times slower than a predicate), and it
+# is often triggered.
+#
+# That's why we hardcode the following cases and check duplicable? instead of
+# using that rescue idiom.
+#++
+class Object
+  # Can you safely dup this object?
+  #
+  # False for +nil+, +false+, +true+, symbol, number, method objects;
+  # true otherwise.
+  def duplicable?
+    true
+  end
+end
+
+class NilClass
+  # +nil+ is not duplicable:
+  #
+  #   nil.duplicable? # => false
+  #   nil.dup         # => TypeError: can't dup NilClass
+  def duplicable?
+    false
+  end
+end
+
+class FalseClass
+  # +false+ is not duplicable:
+  #
+  #   false.duplicable? # => false
+  #   false.dup         # => TypeError: can't dup FalseClass
+  def duplicable?
+    false
+  end
+end
+
+class TrueClass
+  # +true+ is not duplicable:
+  #
+  #   true.duplicable? # => false
+  #   true.dup         # => TypeError: can't dup TrueClass
+  def duplicable?
+    false
+  end
+end
+
+class Symbol
+  # Symbols are not duplicable:
+  #
+  #   :my_symbol.duplicable? # => false
+  #   :my_symbol.dup         # => TypeError: can't dup Symbol
+  def duplicable?
+    false
+  end
+end
+
+class Numeric
+  # Numbers are not duplicable:
+  #
+  #  3.duplicable? # => false
+  #  3.dup         # => TypeError: can't dup Integer
+  def duplicable?
+    false
+  end
+end
+
+require 'bigdecimal'
+class BigDecimal
+  # BigDecimals are duplicable:
+  #
+  # BigDecimal.new("1.2").duplicable? # => true
+  # BigDecimal.new("1.2").dup         # => #<BigDecimal:...,'0.12E1',18(18)>
+  def duplicable?
+    true
+  end
+end
+
+class Method
+  # Methods are not duplicable:
+  #
+  #  method(:puts).duplicable? # => false
+  #  method(:puts).dup         # => TypeError: allocator undefined for Method
+  def duplicable?
+    false
+  end
+end


### PR DESCRIPTION
This [commit](https://github.com/igrigorik/http-2/commit/31b7b20328ef2dd28427d76af1865a409eea2e88) introduced ActiveSupport to use `#deep dup`. This created a dependency on Ruby 2.2.2, which is causing the CI to fail.

Not sure if we need to support previous versions of Ruby, but it doesn't seem necessary to include Active Support for a few methods.