### PR TITLE
buffer wraps string

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ group :test do
   gem 'pry-byebug', platform: :mri
   gem 'rspec', '~> 3.4.0'
   gem 'rspec-autotest'
-  gem 'rubocop', '~> 0.43'
+  gem 'rubocop', '0.43.0'
 end
 
 gemspec

--- a/lib/http/2/connection.rb
+++ b/lib/http/2/connection.rb
@@ -574,7 +574,7 @@ module HTTP2
     #
     # @param frame [Hash]
     def decode_headers(frame)
-      if frame[:payload].is_a? String
+      if frame[:payload].is_a? Buffer
         frame[:payload] = @decompressor.decode(frame[:payload])
       end
 
@@ -588,7 +588,7 @@ module HTTP2
     # @return [Array of Frame]
     def encode_headers(frame)
       payload = frame[:payload]
-      payload = @compressor.encode(payload) unless payload.is_a? String
+      payload = @compressor.encode(payload) unless payload.is_a? Buffer
 
       frames = []
 

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -56,10 +56,10 @@ RSpec.describe HTTP2::Client do
     it 'should raise error on PUSH_PROMISE against non-idle stream' do
       expect do
         s = @client.new_stream
-        s.send HEADERS
+        s.send HEADERS.dup
 
-        @client << set_stream_id(f.generate(PUSH_PROMISE), s.id)
-        @client << set_stream_id(f.generate(PUSH_PROMISE), s.id)
+        @client << set_stream_id(f.generate(PUSH_PROMISE.dup), s.id)
+        @client << set_stream_id(f.generate(PUSH_PROMISE.dup), s.id)
       end.to raise_error(ProtocolError)
     end
 

--- a/spec/connection_spec.rb
+++ b/spec/connection_spec.rb
@@ -149,9 +149,7 @@ RSpec.describe HTTP2::Connection do
       ]
       headers = []
       @conn.on(:frame) do |bytes|
-        # buf[3]: frame's type field
-        buf = Buffer.new(bytes)
-        headers << f.parse(buf) if [1, 5, 9].include?(buf[3].ord)
+        headers << f.parse(bytes) if [1, 5, 9].include?(bytes[3].ord)
       end
 
       stream = @conn.new_stream
@@ -343,10 +341,9 @@ RSpec.describe HTTP2::Connection do
 
     it 'should compress stream headers' do
       @conn.on(:frame) do |bytes|
-        buf = Buffer.new(bytes)
-        expect(buf).not_to include('get')
-        expect(buf).not_to include('http')
-        expect(buf).not_to include('www.example.org') # should be huffman encoded
+        expect(bytes).not_to include('get')
+        expect(bytes).not_to include('http')
+        expect(bytes).not_to include('www.example.org') # should be huffman encoded
       end
 
       stream = @conn.new_stream
@@ -359,9 +356,8 @@ RSpec.describe HTTP2::Connection do
     it 'should generate CONTINUATION if HEADERS is too long' do
       headers = []
       @conn.on(:frame) do |bytes|
-        buf = Buffer.new(bytes)
-        # buf[3]: frame's type field
-        headers << f.parse(buf) if [1, 5, 9].include?(buf[3].ord)
+        # bytes[3]: frame's type field
+        headers << f.parse(bytes) if [1, 5, 9].include?(bytes[3].ord)
       end
 
       stream = @conn.new_stream
@@ -384,9 +380,8 @@ RSpec.describe HTTP2::Connection do
     it 'should not generate CONTINUATION if HEADERS fits exactly in a frame' do
       headers = []
       @conn.on(:frame) do |bytes|
-        # buf[3]: frame's type field
-        buf = Buffer.new(bytes)
-        headers << f.parse(buf) if [1, 5, 9].include?(buf[3].ord)
+        # bytes[3]: frame's type field
+        headers << f.parse(bytes) if [1, 5, 9].include?(bytes[3].ord)
       end
 
       stream = @conn.new_stream
@@ -407,9 +402,8 @@ RSpec.describe HTTP2::Connection do
     it 'should not generate CONTINUATION if HEADERS fits exactly in a frame' do
       headers = []
       @conn.on(:frame) do |bytes|
-        buf = Buffer.new(bytes)
-        # buf[3]: frame's type field
-        headers << f.parse(buf) if [1, 5, 9].include?(buf[3].ord)
+        # bytes[3]: frame's type field
+        headers << f.parse(bytes) if [1, 5, 9].include?(bytes[3].ord)
       end
 
       stream = @conn.new_stream
@@ -430,8 +424,7 @@ RSpec.describe HTTP2::Connection do
     it 'should generate CONTINUATION if HEADERS exceed the max payload by one byte' do
       headers = []
       @conn.on(:frame) do |bytes|
-        buf = Buffer.new(bytes)
-        headers << f.parse(buf) if [1, 5, 9].include?(buf[3].ord)
+        headers << f.parse(bytes) if [1, 5, 9].include?(bytes[3].ord)
       end
 
       stream = @conn.new_stream

--- a/spec/connection_spec.rb
+++ b/spec/connection_spec.rb
@@ -149,8 +149,9 @@ RSpec.describe HTTP2::Connection do
       ]
       headers = []
       @conn.on(:frame) do |bytes|
-        # bytes[3]: frame's type field
-        headers << f.parse(bytes) if [1, 5, 9].include?(bytes[3].ord)
+        # buf[3]: frame's type field
+        buf = Buffer.new(bytes)
+        headers << f.parse(buf) if [1, 5, 9].include?(buf[3].ord)
       end
 
       stream = @conn.new_stream
@@ -342,9 +343,10 @@ RSpec.describe HTTP2::Connection do
 
     it 'should compress stream headers' do
       @conn.on(:frame) do |bytes|
-        expect(bytes).not_to include('get')
-        expect(bytes).not_to include('http')
-        expect(bytes).not_to include('www.example.org') # should be huffman encoded
+        buf = Buffer.new(bytes)
+        expect(buf).not_to include('get')
+        expect(buf).not_to include('http')
+        expect(buf).not_to include('www.example.org') # should be huffman encoded
       end
 
       stream = @conn.new_stream
@@ -357,8 +359,9 @@ RSpec.describe HTTP2::Connection do
     it 'should generate CONTINUATION if HEADERS is too long' do
       headers = []
       @conn.on(:frame) do |bytes|
-        # bytes[3]: frame's type field
-        headers << f.parse(bytes) if [1, 5, 9].include?(bytes[3].ord)
+        buf = Buffer.new(bytes)
+        # buf[3]: frame's type field
+        headers << f.parse(buf) if [1, 5, 9].include?(buf[3].ord)
       end
 
       stream = @conn.new_stream
@@ -381,8 +384,9 @@ RSpec.describe HTTP2::Connection do
     it 'should not generate CONTINUATION if HEADERS fits exactly in a frame' do
       headers = []
       @conn.on(:frame) do |bytes|
-        # bytes[3]: frame's type field
-        headers << f.parse(bytes) if [1, 5, 9].include?(bytes[3].ord)
+        # buf[3]: frame's type field
+        buf = Buffer.new(bytes)
+        headers << f.parse(buf) if [1, 5, 9].include?(buf[3].ord)
       end
 
       stream = @conn.new_stream
@@ -403,8 +407,9 @@ RSpec.describe HTTP2::Connection do
     it 'should not generate CONTINUATION if HEADERS fits exactly in a frame' do
       headers = []
       @conn.on(:frame) do |bytes|
-        # bytes[3]: frame's type field
-        headers << f.parse(bytes) if [1, 5, 9].include?(bytes[3].ord)
+        buf = Buffer.new(bytes)
+        # buf[3]: frame's type field
+        headers << f.parse(buf) if [1, 5, 9].include?(buf[3].ord)
       end
 
       stream = @conn.new_stream
@@ -425,7 +430,8 @@ RSpec.describe HTTP2::Connection do
     it 'should generate CONTINUATION if HEADERS exceed the max payload by one byte' do
       headers = []
       @conn.on(:frame) do |bytes|
-        headers << f.parse(bytes) if [1, 5, 9].include?(bytes[3].ord)
+        buf = Buffer.new(bytes)
+        headers << f.parse(buf) if [1, 5, 9].include?(buf[3].ord)
       end
 
       stream = @conn.new_stream


### PR DESCRIPTION
> TODO: Refactor, it would be better if Buffer were not a String subclass,
>  but rather wrap a string and only expose the mutating API needed so that
>   the possible surface for things to go wrong stays controllable.
>   [Pull #46](https://github.com/igrigorik/http-2/pull/46) 