### PR TITLE
be safe with nils in the connection_error handler

### DIFF
--- a/lib/http/2/connection.rb
+++ b/lib/http/2/connection.rb
@@ -654,7 +654,7 @@ module HTTP2
 
       @state, @error = :closed, error
       klass = error.to_s.split('_').map(&:capitalize).join
-      fail Error.const_get(klass), msg || e.message, e.backtrace || []
+      fail Error.const_get(klass), msg || e&.message, e&.backtrace || []
     end
   end
 end

--- a/lib/http/2/connection.rb
+++ b/lib/http/2/connection.rb
@@ -654,7 +654,9 @@ module HTTP2
 
       @state, @error = :closed, error
       klass = error.to_s.split('_').map(&:capitalize).join
-      fail Error.const_get(klass), msg || e&.message, e&.backtrace || []
+      msg ||= e && e.message
+      backtrace = (e && e.backtrace) || []
+      fail Error.const_get(klass), msg, backtrace
     end
   end
 end


### PR DESCRIPTION
ran into a few states where `msg` _and_ `e` were `nil`
