### PR TITLE
refactor Stream#data to use byteslice

### DIFF
--- a/spec/stream_spec.rb
+++ b/spec/stream_spec.rb
@@ -651,7 +651,28 @@ RSpec.describe HTTP2::Stream do
         expect(@stream).to receive(:send) do |frame|
           expect(frame[:type]).to eq w[:type]
           expect(frame[:flags]).to eq w[:flags]
-          expect(frame[:payload].length).to eq w[:length]
+          expect(frame[:payload].bytesize).to eq w[:length]
+        end
+      end
+
+      @stream.data(data + 'x')
+    end
+
+    it '.data should split large multibyte DATA frames' do
+      data = '🐼' * 16_384
+
+      want = [
+        { type: :data, flags: [], length: 16_384 },
+        { type: :data, flags: [], length: 16_384 },
+        { type: :data, flags: [], length: 16_384 },
+        { type: :data, flags: [], length: 16_384 },
+        { type: :data, flags: [:end_stream], length: 1 }
+      ]
+      want.each do |w|
+        expect(@stream).to receive(:send) do |frame|
+          expect(frame[:type]).to eq w[:type]
+          expect(frame[:flags]).to eq w[:flags]
+          expect(frame[:payload].bytesize).to eq w[:length]
         end
       end
 

--- a/spec/stream_spec.rb
+++ b/spec/stream_spec.rb
@@ -666,7 +666,7 @@ RSpec.describe HTTP2::Stream do
         { type: :data, flags: [], length: 16_384 },
         { type: :data, flags: [], length: 16_384 },
         { type: :data, flags: [], length: 16_384 },
-        { type: :data, flags: [:end_stream], length: 1 }
+        { type: :data, flags: [:end_stream], length: 1 },
       ]
       want.each do |w|
         expect(@stream).to receive(:send) do |frame|


### PR DESCRIPTION
ran into this issue when pushing a PNG through Stream#data, noticed slice! instead of byteslice
- add `Stream#chunk_data` to byteslice payload into max_size, yield each chunk to the block
- add multibyte test to stream_spec
