### PR TITLE
Fix connection_error when Exception is NoMethodError or nil

### DIFF
--- a/lib/http/2/connection.rb
+++ b/lib/http/2/connection.rb
@@ -654,7 +654,14 @@ module HTTP2
 
       @state, @error = :closed, error
       klass = error.to_s.split('_').map(&:capitalize).join
-      fail Error.const_get(klass), msg || e.message, e.backtrace || []
+
+      message = msg
+      message = e.message if message.nil? && e.respond_to?(:message)
+
+      backtrace = []
+      backtrace = e.backtrace if e.respond_to?(:backtrace)
+
+      fail Error.const_get(klass), message, backtrace
     end
   end
 end


### PR DESCRIPTION
When working on [h2spec](https://github.com/summerwind/h2spec), discovered that connection_error exception can be `NoMethodError` or `nil`. Calling `e.message` or `e.backtrace` raises a new exception.

Not sure why the exception would be `NoMethodError` or `nil` (seems strange to me), but this fixes it for now.