### PR TITLE
requiring base64 (Closes #75)

### DIFF
--- a/example/upgrade_server.rb
+++ b/example/upgrade_server.rb
@@ -2,7 +2,6 @@
 
 require_relative 'helper'
 require 'http_parser'
-require 'base64'
 
 options = { port: 8080 }
 OptionParser.new do |opts|

--- a/lib/http/2/server.rb
+++ b/lib/http/2/server.rb
@@ -1,4 +1,4 @@
-require "base64"
+require 'base64'
 module HTTP2
   # HTTP 2.0 server connection class that implements appropriate header
   # compression / decompression algorithms and stream management logic.

--- a/lib/http/2/server.rb
+++ b/lib/http/2/server.rb
@@ -1,3 +1,4 @@
+require "base64"
 module HTTP2
   # HTTP 2.0 server connection class that implements appropriate header
   # compression / decompression algorithms and stream management logic.


### PR DESCRIPTION
@igrigorik as you are using the urlsafe_ version of the decoding, I don't know if it's right to unpack the string myself. So I just required the module. Tell me what you think. The `Base64` is anyway just a small set of wrapper methods around string unpacking. 