### PR TITLE
Fix h2spec 4.2. Frame Size

### DIFF
--- a/lib/http/2/framer.rb
+++ b/lib/http/2/framer.rb
@@ -328,6 +328,8 @@ module HTTP2
       frame = read_common_header(buf)
       return nil if buf.size < 9 + frame[:length]
 
+      fail ProtocolError, 'payload too large' if frame[:length] > DEFAULT_MAX_FRAME_SIZE
+
       buf.read(9)
       payload = buf.read(frame[:length])
 


### PR DESCRIPTION
Previous secure server results:
```
73 tests, 33 passed, 0 skipped, 40 failed

4.2. Frame Size
    × Sends large size frame that exceeds the SETTINGS_MAX_FRAME_SIZE
      - The endpoint MUST send a FRAME_SIZE_ERROR error.
        Expected: GOAWAY frame (ErrorCode: FRAME_SIZE_ERROR)
                  RST_STREAM frame (ErrorCode: FRAME_SIZE_ERROR)
                  Connection close
          Actual: HEADERS frame (Length: 14, Flags: 4)
```

New secure server results:

```
73 tests, 34 passed, 0 skipped, 39 failed

4.2. Frame Size
    ✓ Sends large size frame that exceeds the SETTINGS_MAX_FRAME_SIZE
```