### PR TITLE
Create rake task to run h2spec

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -1,0 +1,19 @@
+
+guard :process, name: 'HTTP/2 Server', command: 'ruby example/server.rb', stop_signal: 'TERM' do
+  watch(%r{^example/(.+)\.rb$})
+  watch(%r{^lib/http/2/(.+)\.rb$})
+
+  watch('Gemfile.lock')
+end
+
+def h2spec
+  puts 'Starting H2 Spec'
+  sleep 0.7
+  system '~/go-workspace/bin/h2spec -p 8080 -o 1 -s 4.2'
+  puts "\n"
+end
+
+guard :shell, name: 'H2 Spec' do
+  watch(%r{^example/(.+)\.rb$})    { h2spec }
+  watch(%r{^lib/http/2/(.+)\.rb$}) { h2spec }
+end

--- a/Guardfile.h2spec
+++ b/Guardfile.h2spec
@@ -1,0 +1,12 @@
+def h2spec
+  puts "Starting H2 Spec"
+  sleep 0.7
+  system '~/go-workspace/bin/h2spec -p 8080 -o 1 -s 5.1'
+  puts "\n"
+end
+
+guard :shell, name:'H2 Spec' do
+  watch(%r{^example/(.+)\.rb$})    { h2spec }
+  watch(%r{^lib/http/2/(.+)\.rb$}) { h2spec }
+end
+

--- a/Rakefile
+++ b/Rakefile
@@ -12,6 +12,15 @@ RSpec::Core::RakeTask.new(:hpack) do |t|
   t.pattern = './spec/hpack_test_spec.rb'
 end
 
+task :h2spec do
+  system 'ruby example/server.rb -p 9000 &', out: File::NULL
+  sleep 1
+
+  system 'spec/h2spec/h2spec.darwin -p 9000'
+
+  system 'kill `pgrep -f example/server.rb`'
+end
+
 RuboCop::RakeTask.new
 YARD::Rake::YardocTask.new
 

--- a/Rakefile
+++ b/Rakefile
@@ -13,6 +13,10 @@ RSpec::Core::RakeTask.new(:hpack) do |t|
 end
 
 task :h2spec do
+  if /darwin/ !~ RUBY_PLATFORM
+    abort "h2spec rake task currently only works on OSX. \nDownload other binaries from https://github.com/summerwind/h2spec/releases"
+  end
+
   system 'ruby example/server.rb -p 9000 &', out: File::NULL
   sleep 1
 

--- a/Rakefile
+++ b/Rakefile
@@ -14,7 +14,8 @@ end
 
 task :h2spec do
   if /darwin/ !~ RUBY_PLATFORM
-    abort "h2spec rake task currently only works on OSX. \nDownload other binaries from https://github.com/summerwind/h2spec/releases"
+    abort "h2spec rake task currently only works on OSX.
+           Download other binaries from https://github.com/summerwind/h2spec/releases"
   end
 
   system 'ruby example/server.rb -p 9000 &', out: File::NULL


### PR DESCRIPTION
`rake h2spec`

Limitations: 
1. Only works on OSX.
2. Only works for non-secure server. Need to figure out how to manage output because it is already too long.

Since the output is long (600 lines), I think we can leave it out of the default task. Alternatively, we could abbreviate the result to `73 tests, 33 passed, 0 skipped, 40 failed`. 

One thing we could do is append the truncated output to the default rake task, but provide full output for `rake h2spec`.