### PR TITLE
h2spec fix 5.1.1. Stream Identifiers

### DIFF
--- a/lib/http/2/connection.rb
+++ b/lib/http/2/connection.rb
@@ -226,6 +226,12 @@ module HTTP2
         else
           case frame[:type]
           when :headers
+            # When even-numbered stream identifier is received,
+            # the endpoint MUST respond with a connection error of type PROTOCOL_ERROR.
+            if frame[ :stream ].even?
+              connection_error
+            end
+
             # The last frame in a sequence of HEADERS/CONTINUATION
             # frames MUST have the END_HEADERS flag set.
             unless frame[:flags].include? :end_headers

--- a/lib/http/2/connection.rb
+++ b/lib/http/2/connection.rb
@@ -226,11 +226,9 @@ module HTTP2
         else
           case frame[:type]
           when :headers
-            # When even-numbered stream identifier is received,
+            # When server receives even-numbered stream identifier,
             # the endpoint MUST respond with a connection error of type PROTOCOL_ERROR.
-            if frame[ :stream ].even?
-              connection_error
-            end
+            connection_error if frame[:stream].even? && is_a?(Server)
 
             # The last frame in a sequence of HEADERS/CONTINUATION
             # frames MUST have the END_HEADERS flag set.

--- a/lib/http/2/connection.rb
+++ b/lib/http/2/connection.rb
@@ -228,7 +228,7 @@ module HTTP2
           when :headers
             # When server receives even-numbered stream identifier,
             # the endpoint MUST respond with a connection error of type PROTOCOL_ERROR.
-            connection_error if frame[:stream].even? && is_a?(Server)
+            connection_error if frame[:stream].even? && self.is_a?(Server)
 
             # The last frame in a sequence of HEADERS/CONTINUATION
             # frames MUST have the END_HEADERS flag set.


### PR DESCRIPTION
      × Sends even-numbered stream identifier
        - The endpoint MUST respond with a connection error of type PROTOCOL_ERROR.

73 tests, 33 passed, 0 skipped, 40 failed