### PR TITLE
Use ALPN instead of NPN

### DIFF
--- a/example/client.rb
+++ b/example/client.rb
@@ -17,9 +17,11 @@ if uri.scheme == 'https'
   ctx = OpenSSL::SSL::SSLContext.new
   ctx.verify_mode = OpenSSL::SSL::VERIFY_NONE
 
-  ctx.npn_protocols = [DRAFT]
-  ctx.npn_select_cb = lambda do |protocols|
-    puts "NPN protocols supported by server: #{protocols}"
+  # For ALPN support, Ruby >= 2.3 and OpenSSL >= 1.0.2 are required
+
+  ctx.alpn_protocols = [DRAFT]
+  ctx.alpn_select_cb = lambda do |protocols|
+    puts "ALPN protocols supported by server: #{protocols}"
     DRAFT if protocols.include? DRAFT
   end
 
@@ -28,8 +30,8 @@ if uri.scheme == 'https'
   sock.hostname = uri.hostname
   sock.connect
 
-  if sock.npn_protocol != DRAFT
-    puts "Failed to negotiate #{DRAFT} via NPN"
+  if sock.alpn_protocol != DRAFT
+    puts "Failed to negotiate #{DRAFT} via ALPN"
     exit
   end
 else


### PR DESCRIPTION
The HTTP/2 specification suggests to use ALPN for HTTP/2 over TLS.

ALPN is supported by Ruby 2.3 and newer. Maybe someone can improve this pull request, so that the code still runs with older Ruby versions.