### PR TITLE
Buffer: also forward the to_s method

### DIFF
--- a/lib/http/2/buffer.rb
+++ b/lib/http/2/buffer.rb
@@ -7,7 +7,7 @@ module HTTP2
     extend Forwardable
 
     def_delegators :@buffer, :ord, :encoding, :setbyte, :unpack,
-                   :size, :each_byte,  :to_str, :length, :inspect,
+                   :size, :each_byte, :to_str, :to_s, :length, :inspect,
                    :[], :[]=, :empty?, :bytesize, :include?
 
     UINT32 = 'N'.freeze


### PR DESCRIPTION
Instead of actual data, the example program "client.rb" sent the string ``"#<HTTP2::Buffer:0x0056529cd1d1a8>"`` when I tried it. Probably this behavior depends on the Ruby version (I have tested with Ruby 2.3.1).

I don't know if there is a better bugfix, but also forwarding the "to_s" method fixes the problem.