### PR TITLE
Update README.md

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -9,7 +9,7 @@ $> ruby client.rb http://localhost:8080/                 # GET
 $> ruby client.rb http://localhost:8080/ -d 'some data'  # POST
 
 # Server push
-$> ruby server.rb -push
+$> ruby server.rb --push
 $> ruby client.rb http://localhost:8080/                 # GET
 
 # TLS + NPN negotiation


### PR DESCRIPTION
fix `ruby server.rb --push`
`-p` its a reserved flag for `port`

```
$ ruby server.rb -push
Starting server on port ush
server.rb:21:in `initialize': getaddrinfo: nodename nor servname provided, or not known (SocketError)
```