### PR TITLE
defer stream closing and state handling

### DIFF
--- a/lib/http/2/connection.rb
+++ b/lib/http/2/connection.rb
@@ -689,5 +689,9 @@ module HTTP2
       backtrace = (e && e.backtrace) || []
       fail Error.const_get(klass), msg, backtrace
     end
+
+    def manage_state(_)
+      yield
+    end
   end
 end

--- a/lib/http/2/flow_buffer.rb
+++ b/lib/http/2/flow_buffer.rb
@@ -52,9 +52,11 @@ module HTTP2
           sent = frame_size
         end
 
-        frames = encode ? encode(frame) : [frame]
-        frames.each { |f| emit(:frame, f) }
-        @remote_window -= sent
+        manage_state(frame) do
+          frames = encode ? encode(frame) : [frame]
+          frames.each { |f| emit(:frame, f) }
+          @remote_window -= sent
+        end
       end
     end
 


### PR DESCRIPTION
fix for #92. after much digging, patching, and discussion, i'm more and more convinced this is the correct path forward. i think this is the least change with the most effect for solving the problems:

* deleting a stream from `Connection/@streams` before :end_stream frame is actually sent
* handling stream state when dealing with data that is larger than the flow control windows

i've tested with my [h2 branch of reel](https://github.com/kenichi/reel/tree/h2), the [h2 client](https://github.com/kenichi/h2) extracted from reel tests, and the [nghttp](https://nghttp2.org/) client.

i've also tested with @ostinelli's [net-http2](https://github.com/ostinelli/net-http2) client, by pulling the latest code, changing the gemspec to >= 0.8.3, commenting out the [patch](https://github.com/ostinelli/net-http2/blob/master/lib/http2_patch.rb). like him, i saw spec failures, but after pointing it (via Gemfile) to this branch, all specs pass.

further ideas, comments, and/or critiques are very welcome.