### PR TITLE
Replace deprecated tmp_ecdh_callback with ecdh_curves

### DIFF
--- a/example/server.rb
+++ b/example/server.rb
@@ -36,9 +36,7 @@ if options[:secure]
     DRAFT
   end
 
-  ctx.tmp_ecdh_callback = lambda do |*_args|
-    OpenSSL::PKey::EC.new 'prime256v1'
-  end
+  ctx.ecdh_curves = "P-256"
 
   server = OpenSSL::SSL::SSLServer.new(server, ctx)
 end

--- a/example/server.rb
+++ b/example/server.rb
@@ -36,7 +36,7 @@ if options[:secure]
     DRAFT
   end
 
-  ctx.ecdh_curves = "P-256"
+  ctx.ecdh_curves = 'P-256'
 
   server = OpenSSL::SSL::SSLServer.new(server, ctx)
 end


### PR DESCRIPTION
`tmp_ecdh_callback=` is deprecated [Note](https://github.com/ruby/openssl/blob/master/History.md)
Replace it with `ecdh_curves= 'P-256'`