### PR TITLE
H2C Upgrade client 

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -37,7 +37,7 @@ Metrics/MethodLength:
 # Offense count: 1
 # Configuration parameters: CountKeywordArgs.
 Metrics/ParameterLists:
-  Max: 6
+  Max: 7
 
 # Offense count: 10
 Metrics/PerceivedComplexity:

--- a/example/upgrade_client.rb
+++ b/example/upgrade_client.rb
@@ -1,0 +1,158 @@
+# frozen_string_literals: true
+
+require_relative 'helper'
+require 'http_parser'
+
+options = {}
+OptionParser.new do |opts|
+  opts.banner = 'Usage: upgrade_client.rb [options]'
+end.parse!
+
+uri = URI.parse(ARGV[0] || 'http://localhost:8080/')
+sock = TCPSocket.new(uri.host, uri.port)
+
+conn = HTTP2::Client.new
+
+def request_header_hash
+  Hash.new do |hash, key|
+    k = key.to_s.downcase
+    k.tr! '_', '-'
+    _, value = hash.find { |header_key, _| header_key.downcase == k }
+    hash[key] = value if value
+  end
+end
+
+conn.on(:frame) do |bytes|
+  sock.print bytes
+  sock.flush
+end
+conn.on(:frame_sent) do |frame|
+  puts "Sent frame: #{frame.inspect}"
+end
+conn.on(:frame_received) do |frame|
+  puts "Received frame: #{frame.inspect}"
+end
+
+
+
+class UpgradeHandler
+  UPGRADE_REQUEST = <<-RESP
+GET %s HTTP/1.1
+Connection: Upgrade, HTTP2-Settings
+HTTP2-Settings: #{HTTP2::Client.settings_header(settings_max_concurrent_streams: 100)}
+Upgrade: h2c
+Host: %s
+User-Agent: http-2 upgrade
+Accept: */*
+
+RESP
+
+  attr_reader :complete, :parsing
+  def initialize(conn, sock)
+    @conn = conn
+    @sock = sock
+    @headers = request_header_hash 
+    @body = ''.b
+    @complete, @parsing = false, false
+    @parser = ::HTTP::Parser.new(self)
+  end
+
+  def request(uri)
+    host = "#{uri.hostname}#{":#{uri.port}" if uri.port != uri.default_port}"
+    req = format(UPGRADE_REQUEST, uri.request_uri, host)
+    puts req
+    @sock << req 
+  end
+
+  def <<(data)
+    @parsing ||= true
+    @parser << data
+    return unless complete
+    upgrade
+  end
+
+  def complete!
+    @complete = true
+  end
+
+  def on_headers_complete(h)
+    @headers.merge!(h)
+    puts "received headers: #{h}"
+  end
+
+  def on_body(chunk)
+    puts "received chunk: #{chunk}":
+    @body << chunk
+  end
+
+  def on_message_complete
+    fail "could not upgrade to h2c" unless @parser.status_code == 101 
+    @parsing = false
+    complete!
+  end
+
+  def upgrade
+    stream = @conn.upgrade
+    log = Logger.new(stream.id)
+
+    stream.on(:close) do
+      log.info 'stream closed'
+    end
+    
+    stream.on(:half_close) do
+      log.info 'closing client-end of the stream'
+    end
+    
+    stream.on(:headers) do |h|
+      log.info "response headers: #{h}"
+    end
+    
+    stream.on(:data) do |d|
+      log.info "response data chunk: <<#{d}>>"
+    end
+    
+    stream.on(:altsvc) do |f|
+      log.info "received ALTSVC #{f}"
+    end
+
+    @conn.on(:promise) do |promise|
+      promise.on(:headers) do |h|
+        log.info "promise headers: #{h}"
+      end
+    
+      promise.on(:data) do |d|
+        log.info "promise data chunk: <<#{d.size}>>"
+      end
+    end
+    
+    @conn.on(:altsvc) do |f|
+      log.info "received ALTSVC #{f}"
+    end
+  end
+end
+
+uh = UpgradeHandler.new(conn, sock)
+puts 'Sending HTTP/1.1 upgrade request'
+uh.request(uri)
+
+while !sock.closed? && !sock.eof?
+  data = sock.read_nonblock(1024)
+
+  begin
+    case
+    when !uh.parsing && !uh.complete
+      uh << data
+    when uh.parsing && !uh.complete
+      uh << data
+    when uh.complete
+      conn << data
+    end
+
+  rescue => e
+    puts "#{e.class} exception: #{e.message} - closing socket."
+    e.backtrace.each { |l| puts "\t" + l }
+    conn.close
+    sock.close
+  end
+end
+

--- a/lib/http/2/client.rb
+++ b/lib/http/2/client.rb
@@ -40,7 +40,7 @@ module HTTP2
 
     # sends the preface and initializes the first stream in half-closed state
     def upgrade
-      fail ProtocolError unless @stream_id == 1 
+      fail ProtocolError unless @stream_id == 1
       send_connection_preface
       new_stream(state: :half_closed_local)
     end

--- a/lib/http/2/client.rb
+++ b/lib/http/2/client.rb
@@ -54,5 +54,10 @@ module HTTP2
       payload = @local_settings.select { |k, v| v != SPEC_DEFAULT_CONNECTION_SETTINGS[k] }
       settings(payload)
     end
+
+    def self.settings_header(**settings)
+      frame = Framer.new.generate(type: :settings, stream: 0, payload: settings)
+      Base64.urlsafe_encode64(frame[9..-1])
+    end
   end
 end

--- a/lib/http/2/client.rb
+++ b/lib/http/2/client.rb
@@ -38,6 +38,13 @@ module HTTP2
       super(frame)
     end
 
+    # sends the preface and initializes the first stream in half-closed state
+    def upgrade
+      fail ProtocolError unless @stream_id == 1 
+      send_connection_preface
+      new_stream(state: :half_closed_local)
+    end
+
     # Emit the connection preface if not yet
     def send_connection_preface
       return unless @state == :waiting_connection_preface

--- a/lib/http/2/stream.rb
+++ b/lib/http/2/stream.rb
@@ -71,7 +71,8 @@ module HTTP2
     # @param exclusive [Boolean]
     # @param window [Integer]
     # @param parent [Stream]
-    def initialize(connection:, id:, weight: 16, dependency: 0, exclusive: false, parent: nil)
+    # @param state [Symbol]
+    def initialize(connection:, id:, weight: 16, dependency: 0, exclusive: false, parent: nil, state: :idle)
       @connection = connection
       @id = id
       @weight = weight
@@ -81,7 +82,7 @@ module HTTP2
       @local_window  = connection.local_settings[:settings_initial_window_size]
       @remote_window = connection.remote_settings[:settings_initial_window_size]
       @parent = parent
-      @state  = :idle
+      @state  = state
       @error  = false
       @closed = false
       @send_buffer = []

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -34,6 +34,23 @@ RSpec.describe HTTP2::Client do
     end
   end
 
+  context 'upgrade' do
+    it 'fails when client has already created streams' do
+      @client.new_stream
+      expect { @client.upgrade }.to raise_error(HTTP2::Error::ProtocolError)
+    end
+
+    it 'sends the preface' do
+      expect(@client).to receive(:send_connection_preface)
+      @client.upgrade
+    end
+
+    it 'initializes the first stream in the half-closed state' do
+      stream = @client.upgrade
+      expect(stream.state).to be(:half_closed_local)
+    end
+  end
+
   context 'push' do
     it 'should disallow client initiated push' do
       expect do

--- a/spec/compressor_spec.rb
+++ b/spec/compressor_spec.rb
@@ -240,8 +240,8 @@ RSpec.describe HTTP2::Header do
 
     context 'encode' do
       it 'downcases the field' do
-        expect(EncodingContext.new.encode([["Content-Length", "5"]]))
-          .to eq(EncodingContext.new.encode([["content-length", "5"]]))
+        expect(EncodingContext.new.encode([['Content-Length', '5']]))
+          .to eq(EncodingContext.new.encode([['content-length', '5']]))
       end
 
       it 'fills :path if empty' do

--- a/spec/compressor_spec.rb
+++ b/spec/compressor_spec.rb
@@ -237,6 +237,18 @@ RSpec.describe HTTP2::Header do
         expect(cc.table.first[0]).to eq 'test2'
       end
     end
+
+    context 'encode' do
+      it 'downcases the field' do
+        expect(EncodingContext.new.encode([["Content-Length", "5"]]))
+          .to eq(EncodingContext.new.encode([["content-length", "5"]]))
+      end
+
+      it 'fills :path if empty' do
+        expect(EncodingContext.new.encode([[':path', '']]))
+          .to eq(EncodingContext.new.encode([[':path', '/']]))
+      end
+    end
   end
 
   spec_examples = [


### PR DESCRIPTION
Fixes #99 

* Adds `#upgrade` method, which allows client to do the HTTP/2 h2c connection dance and start the first stream in the proper state.
* Adds helper method to generate the proper base64 HTTP2-Settings value

@igrigorik if you agree with the signatures, I'll be happy to provide some tests. 