### PR TITLE
Do not remove closed streams immediately

### DIFF
--- a/spec/connection_spec.rb
+++ b/spec/connection_spec.rb
@@ -543,6 +543,20 @@ RSpec.describe HTTP2::Connection do
       end.to raise_error(ProtocolError)
     end
 
+    it 'should not raise an error on frame for a closed stream ID' do
+      srv = Server.new
+      srv << CONNECTION_PREFACE_MAGIC
+
+      stream = srv.new_stream
+      stream.send HEADERS.dup
+      stream.send DATA.dup
+      stream.close
+
+      expect do
+        srv << f.generate(RST_STREAM.dup.merge(stream: stream.id))
+      end.to_not raise_error
+    end
+
     it 'should send GOAWAY frame on connection error' do
       stream = @conn.new_stream
 


### PR DESCRIPTION
Closed streams need to remain in the Connection @streams list so that
frames received for closed streams do not cause a protocol error.
They are cleaned up if closed for 15 seconds when another stream is
closed. 

Fixes #119 