### PR TITLE
Fix warnings in lib.

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -2,3 +2,4 @@ autotest
 --color
 --format documentation
 --order rand
+--warnings

--- a/lib/http/2/connection.rb
+++ b/lib/http/2/connection.rb
@@ -49,9 +49,6 @@ module HTTP2
     # Connection state (:new, :closed).
     attr_reader :state
 
-    # Last connection error if connection is aborted.
-    attr_reader :error
-
     # Size of current connection flow control window (by default, set to
     # infinity, but is automatically updated on receipt of peer settings).
     attr_reader :local_window
@@ -95,6 +92,8 @@ module HTTP2
       @send_buffer = []
       @continuation = []
       @error = nil
+
+      @h2c_upgrade = nil
     end
 
     # Allocates new stream for current connection.


### PR DESCRIPTION
You might like to take a closer look at the `alias error ...` case. I removed the definition that was being overwritten, but that might not be what you were expecting.