### PR TITLE
Fix client when it initially receives data rather than sending it

### DIFF
--- a/lib/http/2/client.rb
+++ b/lib/http/2/client.rb
@@ -38,7 +38,7 @@ module HTTP2
       super
     end
     
-    def <<(data)
+    def connection_management(frame)
       send_connection_preface
       super
     end

--- a/lib/http/2/client.rb
+++ b/lib/http/2/client.rb
@@ -35,7 +35,12 @@ module HTTP2
     # @param frame [Hash]
     def send(frame)
       send_connection_preface
-      super(frame)
+      super
+    end
+    
+    def <<(data)
+      send_connection_preface
+      super
     end
 
     # sends the preface and initializes the first stream in half-closed state

--- a/lib/http/2/client.rb
+++ b/lib/http/2/client.rb
@@ -39,7 +39,7 @@ module HTTP2
       send_connection_preface
       super
     end
-    
+
     def connection_management(frame)
       send_connection_preface
       super

--- a/lib/http/2/client.rb
+++ b/lib/http/2/client.rb
@@ -50,6 +50,13 @@ module HTTP2
       new_stream(state: :half_closed_local)
     end
 
+    def self.settings_header(**settings)
+      frame = Framer.new.generate(type: :settings, stream: 0, payload: settings)
+      Base64.urlsafe_encode64(frame[9..-1])
+    end
+
+    private
+
     # Emit the connection preface if not yet
     def send_connection_preface
       return unless @state == :waiting_connection_preface
@@ -58,11 +65,6 @@ module HTTP2
 
       payload = @local_settings.select { |k, v| v != SPEC_DEFAULT_CONNECTION_SETTINGS[k] }
       settings(payload)
-    end
-
-    def self.settings_header(**settings)
-      frame = Framer.new.generate(type: :settings, stream: 0, payload: settings)
-      Base64.urlsafe_encode64(frame[9..-1])
     end
   end
 end

--- a/lib/http/2/client.rb
+++ b/lib/http/2/client.rb
@@ -25,6 +25,8 @@ module HTTP2
       @local_role   = :client
       @remote_role  = :server
 
+      @connection_preface_sent = false
+
       super
     end
 
@@ -59,8 +61,10 @@ module HTTP2
 
     # Emit the connection preface if not yet
     def send_connection_preface
-      return unless @state == :waiting_connection_preface
-      @state = :connected
+      return if @connection_preface_sent
+
+      @connection_preface_sent = true
+
       emit(:frame, CONNECTION_PREFACE_MAGIC)
 
       payload = @local_settings.select { |k, v| v != SPEC_DEFAULT_CONNECTION_SETTINGS[k] }

--- a/lib/http/2/connection.rb
+++ b/lib/http/2/connection.rb
@@ -350,8 +350,9 @@ module HTTP2
         end
       end
 
+    rescue Error::Error
+      raise
     rescue => e
-      raise if e.is_a?(Error::Error)
       connection_error(e: e)
     end
     alias << receive

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -20,6 +20,22 @@ RSpec.describe HTTP2::Client do
       expect(frames[0]).to eq CONNECTION_PREFACE_MAGIC
       expect(f.parse(frames[1])[:type]).to eq :settings
     end
+    
+    it 'should emit connection header and SETTINGS when receiving data' do
+      frames = []
+
+      @client.on(:frame) { |bytes| frames << bytes }
+
+      # Force client to send connection prefix:
+      # @client.send_connection_preface
+      # @client.ping("foobar12")
+
+      # Server sends a settings frame.
+      @client << f.generate(SETTINGS.dup)
+
+      expect(frames[0]).to eq CONNECTION_PREFACE_MAGIC
+      expect(f.parse(frames[1])[:type]).to eq :settings
+    end
 
     it 'should initialize client with custom connection settings' do
       frames = []

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe HTTP2::Client do
       expect(frames[0]).to eq CONNECTION_PREFACE_MAGIC
       expect(f.parse(frames[1])[:type]).to eq :settings
     end
-    
+
     it 'should emit connection header and SETTINGS when receiving data' do
       frames = []
 

--- a/spec/connection_spec.rb
+++ b/spec/connection_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe HTTP2::Connection do
         expect { @conn.dup << frame }.to raise_error(ProtocolError)
       end
     end
-    
+
     it 'should not raise error if first frame is SETTINGS' do
       expect { @conn << f.generate(SETTINGS.dup) }.to_not raise_error
       expect(@conn.state).to eq :connected


### PR DESCRIPTION
The connection preface wasn't sent if the first operation was to receive data. This is due to a state machine transition to `:connected` in the frame receive mechanism without invoking `#send_connection_preface`.

As an aside, I sort of think it's a bit inefficient to invoke this function on every data receive/send, but perhaps that's an issue for another time.