### PR TITLE
Improve coverage for existing behaviour.

### DIFF
--- a/lib/http/2/connection.rb
+++ b/lib/http/2/connection.rb
@@ -96,6 +96,10 @@ module HTTP2
       @h2c_upgrade = nil
     end
 
+    def closed?
+      @state == :closed
+    end
+
     # Allocates new stream for current connection.
     #
     # @param priority [Integer]

--- a/lib/http/2/stream.rb
+++ b/lib/http/2/stream.rb
@@ -91,6 +91,10 @@ module HTTP2
       on(:local_window) { |v| @local_window_max_size = @local_window = v }
     end
 
+    def closed?
+      @state == :closed
+    end
+
     # Processes incoming HTTP 2.0 frames. The frames must be decoded upstream.
     #
     # @param frame [Hash]

--- a/spec/stream_spec.rb
+++ b/spec/stream_spec.rb
@@ -194,6 +194,7 @@ RSpec.describe HTTP2::Stream do
       it 'should transition to closed if sending RST_STREAM' do
         @stream.close
         expect(@stream.state).to eq :closed
+        expect(@stream).to be_closed
       end
 
       it 'should transition to closed if receiving RST_STREAM' do


### PR DESCRIPTION
- Add `Connection#closed?` and `Stream#closed?`.
- Refactor specs to improve granularity and coverage.
- Specifically spec the behaviour of `Client#send_connection_preface`.

This PR is in preparation for refactoring how `send_connection_preface` works.