### PR TITLE
Proposed changes to enforce proper ordering of pseudo-headers.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,25 +8,41 @@ AllCops:
     - 'vendor/**/*'
     - '**/huffman_statemachine.rb'
 
+Layout/IndentHeredoc:
+  Exclude:
+    - 'lib/tasks/generate_huffman_table.rb'
+
 Metrics/LineLength:
   Max: 120
 
-Lint/EndAlignment:
-  AlignWith: variable
+Metrics/BlockLength:
+  Max: 700
 
-Style/CaseIndentation:
-  IndentWhenRelativeTo: end
+Layout/EndAlignment:
+  EnforcedStyleAlignWith: variable
 
-Style/IndentHash:
+Layout/CaseIndentation:
+  EnforcedStyle: end
+
+Layout/IndentHash:
   EnforcedStyle: consistent
 
-Style/TrailingCommaInLiteral:
+Style/TrailingCommaInArrayLiteral:
   EnforcedStyleForMultiline: comma
 
-Style/SpaceAroundOperators:
+Style/TrailingCommaInHashLiteral:
+  EnforcedStyleForMultiline: comma
+
+Layout/SpaceAroundOperators:
   Enabled: false
 
-Style/ExtraSpacing:
+Layout/ExtraSpacing:
+  Enabled: false
+
+Layout/EmptyLinesAroundExceptionHandlingKeywords:
+  Enabled: false
+
+Naming/UncommunicativeMethodParamName:
   Enabled: false
 
 Style/SignalException:
@@ -44,10 +60,28 @@ Style/ParenthesesAroundCondition:
 Style/IfInsideElse:
   Enabled: false
 
+Style/IfUnlessModifier:
+  Enabled: false
+
+Style/MultilineIfModifier:
+  Enabled: false
+
+Lint/EmptyWhen:
+  Enabled: false
+
 Style/TrailingCommaInArguments:
   Enabled: false
 
 Style/TrailingUnderscoreVariable:
+  Enabled: false
+
+Style/SymbolArray:
+  Enabled: false
+
+Style/CommentedKeyword:
+  Enabled: false
+
+Style/PercentLiteralDelimiters:
   Enabled: false
 
 Performance/TimesMap:
@@ -55,3 +89,4 @@ Performance/TimesMap:
 
 Performance/RedundantBlockCall:
   Enabled: false
+

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -75,14 +75,14 @@ Style/GuardClause:
 # Cop supports --auto-correct.
 # Configuration parameters: SupportedStyles, IndentationWidth.
 # SupportedStyles: special_inside_parentheses, consistent, align_brackets
-Style/IndentArray:
+Layout/IndentArray:
   EnforcedStyle: consistent
 
 # Offense count: 1
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, SupportedStyles.
 # SupportedStyles: symmetrical, new_line, same_line
-Style/MultilineArrayBraceLayout:
+Layout/MultilineArrayBraceLayout:
   Exclude:
     - 'spec/compressor_spec.rb'
 
@@ -90,7 +90,7 @@ Style/MultilineArrayBraceLayout:
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, SupportedStyles.
 # SupportedStyles: symmetrical, new_line, same_line
-Style/MultilineHashBraceLayout:
+Layout/MultilineHashBraceLayout:
   Exclude:
     - 'spec/compressor_spec.rb'
 

--- a/Guardfile
+++ b/Guardfile
@@ -1,4 +1,3 @@
-
 guard :process, name: 'HTTP/2 Server', command: 'ruby example/server.rb', stop_signal: 'TERM' do
   watch(%r{^example/(.+)\.rb$})
   watch(%r{^lib/http/2/(.+)\.rb$})

--- a/example/client.rb
+++ b/example/client.rb
@@ -114,7 +114,7 @@ while !sock.closed? && !sock.eof?
 
   begin
     conn << data
-  rescue => e
+  rescue StandardError => e
     puts "#{e.class} exception: #{e.message} - closing socket."
     e.backtrace.each { |l| puts "\t" + l }
     sock.close

--- a/example/server.rb
+++ b/example/server.rb
@@ -130,7 +130,7 @@ loop do
 
     begin
       conn << data
-    rescue => e
+    rescue StandardError => e
       puts "#{e.class} exception: #{e.message} - closing socket."
       e.backtrace.each { |l| puts "\t" + l }
       sock.close

--- a/example/upgrade_client.rb
+++ b/example/upgrade_client.rb
@@ -34,16 +34,16 @@ end
 
 # upgrader module
 class UpgradeHandler
-  UPGRADE_REQUEST = <<-RESP.freeze
-GET %s HTTP/1.1
-Connection: Upgrade, HTTP2-Settings
-HTTP2-Settings: #{HTTP2::Client.settings_header(settings_max_concurrent_streams: 100)}
-Upgrade: h2c
-Host: %s
-User-Agent: http-2 upgrade
-Accept: */*
+  UPGRADE_REQUEST = <<-RESP.strip_heredoc.freeze
+    GET %s HTTP/1.1
+    Connection: Upgrade, HTTP2-Settings
+    HTTP2-Settings: #{HTTP2::Client.settings_header(settings_max_concurrent_streams: 100)}
+    Upgrade: h2c
+    Host: %s
+    User-Agent: http-2 upgrade
+    Accept: */*
 
-RESP
+  RESP
 
   attr_reader :complete, :parsing
   def initialize(conn, sock)
@@ -73,9 +73,9 @@ RESP
     @complete = true
   end
 
-  def on_headers_complete(h)
-    @headers.merge!(h)
-    puts "received headers: #{h}"
+  def on_headers_complete(headers)
+    @headers.merge!(headers)
+    puts "received headers: #{headers}"
   end
 
   def on_body(chunk)
@@ -144,8 +144,7 @@ while !sock.closed? && !sock.eof?
     elsif uh.complete
       conn << data
     end
-
-  rescue => e
+  rescue StandardError => e
     puts "#{e.class} exception: #{e.message} - closing socket."
     e.backtrace.each { |l| puts "\t" + l }
     conn.close

--- a/example/upgrade_server.rb
+++ b/example/upgrade_server.rb
@@ -39,12 +39,12 @@ end
 
 class UpgradeHandler
   VALID_UPGRADE_METHODS = %w(GET OPTIONS).freeze
-  UPGRADE_RESPONSE = <<-RESP
-HTTP/1.1 101 Switching Protocols
-Connection: Upgrade
-Upgrade: h2c
+  UPGRADE_RESPONSE = <<-RESP.strip_heredoc.freeze
+    HTTP/1.1 101 Switching Protocols
+    Connection: Upgrade
+    Upgrade: h2c
 
-RESP
+  RESP
 
   attr_reader :complete, :headers, :body, :parsing
 
@@ -191,7 +191,7 @@ loop do
         conn << data
       end
 
-    rescue => e
+    rescue StandardError => e
       puts "Exception: #{e}, #{e.message} - closing socket."
       puts e.backtrace.last(10).join("\n")
       sock.close

--- a/http-2.gemspec
+++ b/http-2.gemspec
@@ -1,5 +1,4 @@
-# coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('../lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'http/2/version'
 

--- a/lib/http/2/client.rb
+++ b/lib/http/2/client.rb
@@ -51,7 +51,7 @@ module HTTP2
       @state = :connected
       emit(:frame, CONNECTION_PREFACE_MAGIC)
 
-      payload = @local_settings.select { |k, v| v != SPEC_DEFAULT_CONNECTION_SETTINGS[k] }
+      payload = @local_settings.reject { |k, v| v == SPEC_DEFAULT_CONNECTION_SETTINGS[k] }
       settings(payload)
     end
 

--- a/lib/http/2/compressor.rb
+++ b/lib/http/2/compressor.rb
@@ -199,7 +199,7 @@ module HTTP2
         commands = []
         # Literals commands are marked with :noindex when index is not used
         noindex = [:static, :never].include?(@options[:index])
-        headers.each do |field, value|
+        headers.sort.each do |field, value|
           # Literal header names MUST be translated to lowercase before
           # encoding and transmission.
           field = field.downcase
@@ -550,7 +550,7 @@ module HTTP2
       def decode(buf)
         list = []
         list << @cc.process(header(buf)) until buf.empty?
-        list.compact
+        list.compact.sort
       end
     end
   end

--- a/lib/http/2/connection.rb
+++ b/lib/http/2/connection.rb
@@ -20,9 +20,9 @@ module HTTP2
 
   DEFAULT_CONNECTION_SETTINGS = {
     settings_header_table_size:       4096,
-    settings_enable_push:             1,     # enabled for servers
+    settings_enable_push:             1,                     # enabled for servers
     settings_max_concurrent_streams:  100,
-    settings_initial_window_size:     65_535, #
+    settings_initial_window_size:     65_535,
     settings_max_frame_size:          16_384,
     settings_max_header_list_size:    2**31 - 1,             # unlimited
   }.freeze
@@ -354,7 +354,7 @@ module HTTP2
         end
       end
 
-    rescue => e
+    rescue StandardError => e
       raise if e.is_a?(Error::Error)
       connection_error(e: e)
     end
@@ -496,7 +496,7 @@ module HTTP2
           # allowed frame size (2^24-1 or 16,777,215 octets), inclusive.
           # Values outside this range MUST be treated as a connection error
           # (Section 5.4.1) of type PROTOCOL_ERROR.
-          unless 16_384 <= v && v <= 16_777_215
+          unless v >= 16_384 && v <= 16_777_215
             return ProtocolError.new("invalid #{key} value")
           end
         when :settings_max_header_list_size
@@ -606,7 +606,7 @@ module HTTP2
         frame[:payload] = @decompressor.decode(frame[:payload])
       end
 
-    rescue => e
+    rescue StandardError => e
       connection_error(:compression_error, e: e)
     end
 
@@ -637,7 +637,7 @@ module HTTP2
 
       frames
 
-    rescue => e
+    rescue StandardError => e
       connection_error(:compression_error, e: e)
       nil
     end
@@ -705,4 +705,5 @@ module HTTP2
       yield
     end
   end
+  # rubocop:enable ClassLength
 end

--- a/lib/http/2/framer.rb
+++ b/lib/http/2/framer.rb
@@ -359,14 +359,14 @@ module HTTP2
         if frame[:flags].include? :priority
           e_sd = payload.read_uint32
           frame[:stream_dependency] = e_sd & RBIT
-          frame[:exclusive] = (e_sd & EBIT) != 0 # rubocop:disable Style/NumericPredicate
+          frame[:exclusive] = (e_sd & EBIT) != 0
           frame[:weight] = payload.getbyte + 1
         end
         frame[:payload] = payload.read(frame[:length])
       when :priority
         e_sd = payload.read_uint32
         frame[:stream_dependency] = e_sd & RBIT
-        frame[:exclusive] = (e_sd & EBIT) != 0 # rubocop:disable Style/NumericPredicate
+        frame[:exclusive] = (e_sd & EBIT) != 0
         frame[:weight] = payload.getbyte + 1
       when :rst_stream
         frame[:error] = unpack_error payload.read_uint32
@@ -442,4 +442,5 @@ module HTTP2
       name || error
     end
   end
+  # rubocop:enable ClassLength
 end

--- a/spec/compressor_spec.rb
+++ b/spec/compressor_spec.rb
@@ -257,8 +257,8 @@ RSpec.describe HTTP2::Header do
       table_size: 4096,
       huffman: :never,
       streams: [
-        { wire: "8286 8441 0f77 7777 2e65 7861 6d70 6c65
-                 2e63 6f6d",
+        { wire: '410f 7777 772e 6578 616d 706c 652e 636f
+                 6d82 8486',
           emitted: [
             [':method', 'GET'],
             [':scheme', 'http'],
@@ -270,7 +270,7 @@ RSpec.describe HTTP2::Header do
           ],
           table_size: 57,
         },
-        { wire: '8286 84be 5808 6e6f 2d63 6163 6865',
+        { wire: 'be82 8486 5808 6e6f 2d63 6163 6865',
           emitted: [
             [':method', 'GET'],
             [':scheme', 'http'],
@@ -284,8 +284,8 @@ RSpec.describe HTTP2::Header do
           ],
           table_size: 110,
         },
-        { wire: "8287 85bf 400a 6375 7374 6f6d 2d6b 6579
-                 0c63 7573 746f 6d2d 7661 6c75 65",
+        { wire: 'bf82 8587 400a 6375 7374 6f6d 2d6b 6579
+                 0c63 7573 746f 6d2d 7661 6c75 65',
           emitted: [
             [':method', 'GET'],
             [':scheme', 'https'],
@@ -307,7 +307,8 @@ RSpec.describe HTTP2::Header do
       table_size: 4096,
       huffman: :always,
       streams: [
-        { wire: '8286 8441 8cf1 e3c2 e5f2 3a6b a0ab 90f4 ff',
+        { wire: '418c f1e3 c2e5 f23a 6ba0 ab90 f4ff 8284
+                 86',
           emitted: [
             [':method', 'GET'],
             [':scheme', 'http'],
@@ -319,7 +320,7 @@ RSpec.describe HTTP2::Header do
           ],
           table_size: 57,
         },
-        { wire: '8286 84be 5886 a8eb 1064 9cbf',
+        { wire: 'be82 8486 5886 a8eb 1064 9cbf',
           emitted: [
             [':method', 'GET'],
             [':scheme', 'http'],
@@ -333,8 +334,8 @@ RSpec.describe HTTP2::Header do
           ],
           table_size: 110,
         },
-        { wire: "8287 85bf 4088 25a8 49e9 5ba9 7d7f 8925
-                 a849 e95b b8e8 b4bf",
+        { wire: 'bf82 8587 4088 25a8 49e9 5ba9 7d7f 8925
+                 a849 e95b b8e8 b4bf',
           emitted: [
             [':method', 'GET'],
             [':scheme', 'https'],
@@ -356,11 +357,11 @@ RSpec.describe HTTP2::Header do
       table_size: 256,
       huffman: :never,
       streams: [
-        { wire: "4803 3330 3258 0770 7269 7661 7465 611d
+        { wire: '4803 3330 3258 0770 7269 7661 7465 611d
                  4d6f 6e2c 2032 3120 4f63 7420 3230 3133
                  2032 303a 3133 3a32 3120 474d 546e 1768
                  7474 7073 3a2f 2f77 7777 2e65 7861 6d70
-                 6c65 2e63 6f6d",
+                 6c65 2e63 6f6d',
           emitted: [
             [':status', '302'],
             ['cache-control', 'private'],
@@ -390,13 +391,13 @@ RSpec.describe HTTP2::Header do
           ],
           table_size: 222,
         },
-        { wire: "88c1 611d 4d6f 6e2c 2032 3120 4f63 7420
-                 3230 3133 2032 303a 3133 3a32 3220 474d
-                 54c0 5a04 677a 6970 7738 666f 6f3d 4153
+        { wire: '88c1 5a04 677a 6970 611d 4d6f 6e2c 2032
+                 3120 4f63 7420 3230 3133 2032 303a 3133
+                 3a32 3220 474d 54c1 7738 666f 6f3d 4153
                  444a 4b48 514b 425a 584f 5157 454f 5049
                  5541 5851 5745 4f49 553b 206d 6178 2d61
                  6765 3d33 3630 303b 2076 6572 7369 6f6e
-                 3d31",
+                 3d31',
           emitted: [
             [':status', '200'],
             ['cache-control', 'private'],
@@ -419,10 +420,10 @@ RSpec.describe HTTP2::Header do
       table_size: 256,
       huffman: :always,
       streams: [
-        { wire: "4882 6402 5885 aec3 771a 4b61 96d0 7abe
+        { wire: '4882 6402 5885 aec3 771a 4b61 96d0 7abe
                  9410 54d4 44a8 2005 9504 0b81 66e0 82a6
                  2d1b ff6e 919d 29ad 1718 63c7 8f0b 97c8
-                 e9ae 82ae 43d3",
+                 e9ae 82ae 43d3',
           emitted: [
             [':status', '302'],
             ['cache-control', 'private'],
@@ -452,11 +453,11 @@ RSpec.describe HTTP2::Header do
           ],
           table_size: 222,
         },
-        { wire: "88c1 6196 d07a be94 1054 d444 a820 0595
-                 040b 8166 e084 a62d 1bff c05a 839b d9ab
+        { wire: '88c1 5a83 9bd9 ab61 96d0 7abe 9410 54d4
+                 44a8 2005 9504 0b81 66e0 84a6 2d1b ffc1
                  77ad 94e7 821d d7f2 e6c7 b335 dfdf cd5b
                  3960 d5af 2708 7f36 72c1 ab27 0fb5 291f
-                 9587 3160 65c0 03ed 4ee5 b106 3d50 07",
+                 9587 3160 65c0 03ed 4ee5 b106 3d50 07',
           emitted: [
             [':status', '200'],
             ['cache-control', 'private'],
@@ -494,12 +495,13 @@ RSpec.describe HTTP2::Header do
             end
             it 'should emit expected headers' do
               subject
-              # order-perserving compare
-              expect(@emitted).to eq ex[:streams][nth][:emitted]
+              # Sorted compare (pseudo-headers should always be first.)
+              expect(@emitted).to eq ex[:streams][nth][:emitted].sort
             end
             it 'should update header table' do
               subject
-              expect(@dc.instance_eval { @cc.table }).to eq ex[:streams][nth][:table]
+              # Sorted comparison of updated header table.
+              expect((@dc.instance_eval { @cc.table }).sort).to eq ex[:streams][nth][:table].sort
             end
             it 'should compute header table size' do
               subject
@@ -533,7 +535,8 @@ RSpec.describe HTTP2::Header do
             end
             it 'should update header table' do
               subject
-              expect(@cc.instance_eval { @cc.table }).to eq ex[:streams][nth][:table]
+              # Sorted comparison of updated header table.
+              expect((@cc.instance_eval { @cc.table }).sort).to eq ex[:streams][nth][:table].sort
             end
             it 'should compute header table size' do
               subject

--- a/spec/framer_spec.rb
+++ b/spec/framer_spec.rb
@@ -341,11 +341,11 @@ RSpec.describe HTTP2::Framer do
         length: 44,
         type: :altsvc,
         stream: 1,
-        max_age: 1_402_290_402,	   # 4
-        port: 8080,		   # 2
-        proto: 'h2-13',		   # 1 + 5
-        host: 'www.example.com',   # 1 + 15
-        origin: 'www.example.com', # 15
+        max_age: 1_402_290_402,     # 4
+        port: 8080,                 # 2
+        proto: 'h2-13',             # 1 + 5
+        host: 'www.example.com',    # 1 + 15
+        origin: 'www.example.com',  # 15
       }
       bytes = f.generate(frame)
       expected = [0, 43, 0xa, 0, 1, 1_402_290_402, 8080].pack('CnCCNNn')

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -10,9 +10,11 @@ Coveralls.wear! if ENV['CI']
 
 require 'http/2'
 
+# rubocop: disable Style/MixinUsage
 include HTTP2
 include HTTP2::Header
 include HTTP2::Error
+# rubocop: enable Style/MixinUsage
 
 DATA = {
   type: :data,


### PR DESCRIPTION
Ilya, here are my recommended changes.  I also updated to latest Rubocop gem and eliminated new violations either by disabling them or making appropriate style/layout changes.  All tests are passing on my machine. 