### PR TITLE
Add strict mode flag.

### DIFF
--- a/lib/http/2/connection.rb
+++ b/lib/http/2/connection.rb
@@ -46,6 +46,9 @@ module HTTP2
     include Emitter
     include Error
 
+    # Enforce RFC conformant behaviour.
+    attr_reader :strict
+
     # Connection state (:new, :closed).
     attr_reader :state
 
@@ -69,7 +72,9 @@ module HTTP2
 
     # Initializes new connection object.
     #
-    def initialize(**settings)
+    def initialize(strict: false, **settings)
+      @strict = strict
+
       @local_settings  = DEFAULT_CONNECTION_SETTINGS.merge(settings)
       @remote_settings = SPEC_DEFAULT_CONNECTION_SETTINGS.dup
 


### PR DESCRIPTION
Add a `strict:` flag to `Connection`. We can then make an efficiency/conformance trade off according to users requirements, and allow users to test non-conformance (by setting strict: false so that invalid behaviour would not be rejected).

I suggest we use this flag initially to gate the following checks:

- Ensure correct order of headers on both client request/response and server request/response (whether this sorts input data or just fails on invalid input still needs to be figured out).
- Ensure that streams don't enter invalid states or make invalid transitions (e.g. sending headers twice).
- Any other high level RFC conformance which can be done in a reasonably efficient way.

This PR simply adds the flag, and it defaults to false. Depending on how the rest of the checks are implemented, we could make the default true.

If we can get consensus on this approach, I will merge it and then we can work on better RFC compliance. I would be happy to hear any arguments for making the default `true` or `false`. I initially thought `true` would be good, but I don't want to risk breaking upstream code. If it's opt in, at least upstream users are making a conscious decision that it's what they want. Maybe in the future it could be the default.

cc @HoneyryderChuck @byronformwalt @ostinelli @kenichi @igrigorik 