### PR TITLE
Added enforcement of protocol handling for out-of-order headers

### DIFF
--- a/lib/http/2/connection.rb
+++ b/lib/http/2/connection.rb
@@ -606,8 +606,12 @@ module HTTP2
         frame[:payload] = @decompressor.decode(frame[:payload])
       end
 
-    rescue StandardError => e
+    rescue CompressionError => e
       connection_error(:compression_error, e: e)
+    rescue ProtocolError => e
+      connection_error(:protocol_error, e: e)
+    rescue StandardError => e
+      connection_error(:internal_error, e: e)
     end
 
     # Encode headers payload and update connection compressor state.


### PR DESCRIPTION
- Implemented validation (order and casing) of received headers. Failure must trigger a stream error (PROTOCOL_ERROR)
- Header compressor now emits pseudo-headers ahead of the rest (by partitioning supplied list)