### PR TITLE
skip nils in output when processing headers

### DIFF
--- a/lib/http/2/compressor.rb
+++ b/lib/http/2/compressor.rb
@@ -139,7 +139,8 @@ module HTTP2
       # - http://tools.ietf.org/html/draft-ietf-httpbis-header-compression-10#section-4.1
       #
       # @param cmd [Hash] { type:, name:, value:, index: }
-      # @return [Array] +[name, value]+ header field that is added to the decoded header list
+      # @return [Array, nil] +[name, value]+ header field that is added to the decoded header list,
+      #                                      or nil if +cmd[:type]+ is +:changetablesize+
       def process(cmd)
         emit = nil
 

--- a/lib/http/2/compressor.rb
+++ b/lib/http/2/compressor.rb
@@ -553,6 +553,7 @@ module HTTP2
         decoding_pseudo_headers = true
         until buf.empty?
           next_header = @cc.process(header(buf))
+          next if next_header.nil?
           is_pseudo_header = next_header.first.start_with? ':'
           if !decoding_pseudo_headers && is_pseudo_header
             fail ProtocolError, 'one or more pseudo headers encountered after regular headers'
@@ -560,7 +561,7 @@ module HTTP2
           decoding_pseudo_headers = is_pseudo_header
           list << next_header
         end
-        list.compact
+        list
       end
     end
   end

--- a/spec/compressor_spec.rb
+++ b/spec/compressor_spec.rb
@@ -546,7 +546,7 @@ RSpec.describe HTTP2::Header do
         },
       ],
     },
-    { title: 'D.6.a.  Response Examples with Huffman - nginx 1.14-1.15.2 responses',
+    { title: 'D.6.a.  Response Examples with Huffman - dynamic table size updates should not trigger exceptions',
       type: :response,
       table_size: 4096,
       huffman: :always,

--- a/spec/compressor_spec.rb
+++ b/spec/compressor_spec.rb
@@ -594,6 +594,17 @@ RSpec.describe HTTP2::Header do
         end
       end
     end
+
+    it 'handle nginx header payloads with space prefix' do
+      pl = " \x88v\x89\xAAcU\xE5\x80\xAE\x16\xD7\x17a\x96\xDDm_J\t\xF52\xDBB\x82\x00^P\x02\xB8\xD3w\x1A\x02\x98\xB4o_\x8B\x1Du\xD0b\r&=LtA\xEA\\\x0256"
+      expect(d.decode(Buffer.new(pl))).to eq([
+        [":status", "200"],
+        ["server", "nginx/1.15.2"],
+        ["date", "Sun, 29 Jul 2018 02:45:40 GMT"],
+        ["content-type", "application/json"],
+        ["content-length", "56"]
+      ])
+    end
   end
 
   context 'encode' do

--- a/spec/compressor_spec.rb
+++ b/spec/compressor_spec.rb
@@ -595,7 +595,7 @@ RSpec.describe HTTP2::Header do
       end
     end
 
-    it 'handle nginx header payloads with space prefix' do
+    it 'handles nginx header payloads' do
       pl = " \x88v\x89\xAAcU\xE5\x80\xAE\x16\xD7\x17a\x96\xDDm_J\t\xF52\xDBB\x82\x00^P\x02\xB8\xD3w\x1A\x02\x98\xB4o_" \
            + "\x8B\x1Du\xD0b\r&=LtA\xEA\\\x0256"
       expect(d.decode(Buffer.new(pl))).to eq([

--- a/spec/compressor_spec.rb
+++ b/spec/compressor_spec.rb
@@ -596,13 +596,14 @@ RSpec.describe HTTP2::Header do
     end
 
     it 'handle nginx header payloads with space prefix' do
-      pl = " \x88v\x89\xAAcU\xE5\x80\xAE\x16\xD7\x17a\x96\xDDm_J\t\xF52\xDBB\x82\x00^P\x02\xB8\xD3w\x1A\x02\x98\xB4o_\x8B\x1Du\xD0b\r&=LtA\xEA\\\x0256"
+      pl = " \x88v\x89\xAAcU\xE5\x80\xAE\x16\xD7\x17a\x96\xDDm_J\t\xF52\xDBB\x82\x00^P\x02\xB8\xD3w\x1A\x02\x98\xB4o_" \
+           + "\x8B\x1Du\xD0b\r&=LtA\xEA\\\x0256"
       expect(d.decode(Buffer.new(pl))).to eq([
-        [":status", "200"],
-        ["server", "nginx/1.15.2"],
-        ["date", "Sun, 29 Jul 2018 02:45:40 GMT"],
-        ["content-type", "application/json"],
-        ["content-length", "56"]
+        [':status', '200'],
+        ['server', 'nginx/1.15.2'],
+        ['date', 'Sun, 29 Jul 2018 02:45:40 GMT'],
+        ['content-type', 'application/json'],
+        ['content-length', '56'],
       ])
     end
   end

--- a/spec/compressor_spec.rb
+++ b/spec/compressor_spec.rb
@@ -546,6 +546,22 @@ RSpec.describe HTTP2::Header do
         },
       ],
     },
+    { title: 'D.6.a.  Response Examples with Huffman - nginx 1.14-1.15.2 responses',
+      type: :response,
+      table_size: 4096,
+      huffman: :always,
+      bypass_encoder: true,
+      streams: [
+        { wire: '2088 7689 aa63 55e5 80ae 16d7 17',
+          emitted: [
+            [':status', '200'],
+            ['server', 'nginx/1.15.2'],
+          ],
+          table: [],
+          table_size: 0,
+        },
+      ],
+    },
   ]
 
   context 'decode' do
@@ -593,18 +609,6 @@ RSpec.describe HTTP2::Header do
           end
         end
       end
-    end
-
-    it 'handles nginx header payloads' do
-      pl = " \x88v\x89\xAAcU\xE5\x80\xAE\x16\xD7\x17a\x96\xDDm_J\t\xF52\xDBB\x82\x00^P\x02\xB8\xD3w\x1A\x02\x98\xB4o_" \
-           + "\x8B\x1Du\xD0b\r&=LtA\xEA\\\x0256"
-      expect(d.decode(Buffer.new(pl))).to eq([
-        [':status', '200'],
-        ['server', 'nginx/1.15.2'],
-        ['date', 'Sun, 29 Jul 2018 02:45:40 GMT'],
-        ['content-type', 'application/json'],
-        ['content-length', '56'],
-      ])
     end
   end
 


### PR DESCRIPTION
see https://github.com/igrigorik/http-2/pull/136#issuecomment-408554647

rubocop did not like the `if` wrapper so `next if` it is.

this change also drops the number of hpack spec failures from 87 to 25 for me locally.