### PR TITLE
ignore management frames for a period after closing a connection

### DIFF
--- a/spec/connection_spec.rb
+++ b/spec/connection_spec.rb
@@ -542,6 +542,13 @@ RSpec.describe HTTP2::Connection do
       expect { @conn.new_stream }.to raise_error(ConnectionClosed)
     end
 
+    it 'should not raise error when receiving connection management frames after closing' do
+      @conn.goaway
+      expect(@conn).to be_closed
+
+      expect { @conn << f.generate(PING.dup) }.not_to raise_error(ProtocolError)
+    end
+
     it 'should process connection management frames after GOAWAY' do
       @conn << f.generate(SETTINGS.dup)
       @conn << f.generate(HEADERS.dup)

--- a/spec/connection_spec.rb
+++ b/spec/connection_spec.rb
@@ -542,7 +542,7 @@ RSpec.describe HTTP2::Connection do
       expect { @conn.new_stream }.to raise_error(ConnectionClosed)
     end
 
-    it 'should not raise error when receiving connection management frames after closing' do
+    it 'should not raise error when receiving connection management frames immediately after emitting goaway' do
       @conn.goaway
       expect(@conn).to be_closed
 

--- a/spec/connection_spec.rb
+++ b/spec/connection_spec.rb
@@ -546,7 +546,9 @@ RSpec.describe HTTP2::Connection do
       @conn.goaway
       expect(@conn).to be_closed
 
+      expect { @conn << f.generate(SETTINGS.dup) }.not_to raise_error(ProtocolError)
       expect { @conn << f.generate(PING.dup) }.not_to raise_error(ProtocolError)
+      expect { @conn << f.generate(GOAWAY.dup) }.not_to raise_error(ProtocolError)
     end
 
     it 'should process connection management frames after GOAWAY' do


### PR DESCRIPTION
Will fix #139 .