### PR TITLE
Fix example code, remove rails method

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,7 @@ AllCops:
 Layout/IndentHeredoc:
   Exclude:
     - 'lib/tasks/generate_huffman_table.rb'
+    - 'example/*'
 
 Metrics/LineLength:
   Max: 120

--- a/example/upgrade_client.rb
+++ b/example/upgrade_client.rb
@@ -34,14 +34,14 @@ end
 
 # upgrader module
 class UpgradeHandler
-  UPGRADE_REQUEST = <<-RESP.strip_heredoc.freeze
-    GET %s HTTP/1.1
-    Connection: Upgrade, HTTP2-Settings
-    HTTP2-Settings: #{HTTP2::Client.settings_header(settings_max_concurrent_streams: 100)}
-    Upgrade: h2c
-    Host: %s
-    User-Agent: http-2 upgrade
-    Accept: */*
+  UPGRADE_REQUEST = <<-RESP.freeze
+GET %s HTTP/1.1
+Connection: Upgrade, HTTP2-Settings
+HTTP2-Settings: #{HTTP2::Client.settings_header(settings_max_concurrent_streams: 100)}
+Upgrade: h2c
+Host: %s
+User-Agent: http-2 upgrade
+Accept: */*
 
   RESP
 

--- a/example/upgrade_client.rb
+++ b/example/upgrade_client.rb
@@ -34,7 +34,7 @@ end
 
 # upgrader module
 class UpgradeHandler
-  UPGRADE_REQUEST = <<-RESP.freeze
+  UPGRADE_REQUEST = <<RESP.freeze
 GET %s HTTP/1.1
 Connection: Upgrade, HTTP2-Settings
 HTTP2-Settings: #{HTTP2::Client.settings_header(settings_max_concurrent_streams: 100)}
@@ -43,7 +43,7 @@ Host: %s
 User-Agent: http-2 upgrade
 Accept: */*
 
-  RESP
+RESP
 
   attr_reader :complete, :parsing
   def initialize(conn, sock)

--- a/example/upgrade_server.rb
+++ b/example/upgrade_server.rb
@@ -39,12 +39,12 @@ end
 
 class UpgradeHandler
   VALID_UPGRADE_METHODS = %w(GET OPTIONS).freeze
-  UPGRADE_RESPONSE = <<-RESP.freeze
+  UPGRADE_RESPONSE = <<RESP.freeze
 HTTP/1.1 101 Switching Protocols
 Connection: Upgrade
 Upgrade: h2c
 
-  RESP
+RESP
 
   attr_reader :complete, :headers, :body, :parsing
 

--- a/example/upgrade_server.rb
+++ b/example/upgrade_server.rb
@@ -39,10 +39,10 @@ end
 
 class UpgradeHandler
   VALID_UPGRADE_METHODS = %w(GET OPTIONS).freeze
-  UPGRADE_RESPONSE = <<-RESP.strip_heredoc.freeze
-    HTTP/1.1 101 Switching Protocols
-    Connection: Upgrade
-    Upgrade: h2c
+  UPGRADE_RESPONSE = <<-RESP.freeze
+HTTP/1.1 101 Switching Protocols
+Connection: Upgrade
+Upgrade: h2c
 
   RESP
 


### PR DESCRIPTION
`String#strip_heredoc` is not a ruby method, it's a Rails method.