### PR TITLE
Fix cleaning up recently closed streams

### DIFF
--- a/http-2.gemspec
+++ b/http-2.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 1.3'
+  spec.add_development_dependency 'bundler'
 end


### PR DESCRIPTION
Ever since 16dec9f2c44d3a525a49fe92bc15c7b79e9de097 in 2018
@streams_recently_closed cleanup was broken.

`to_delete` contains hash of { stream_id => time } so in
`to_delete.each do |stream_id|` `stream_id` is actually array of `[
stream_id, time ]`.

This leads to the same memory leak as there was before the first cleanup
but also adds heavy CPU usage when thousands of streams are being
checked on every stream close.

Since 15s delayed cleanup was intended but actually infinite delay was
added so 15s was never tested in production code and thus might be not
enough.

This change also improves performance of searching streams to delete by
relying on the fact that Ruby Hash is ordered and so once fresh stream
was met we can stop searching.

Also minor performance and memory improvement by storing only timestamp
instead of Time object.

Extracted this part of the code to a separate function for test
convenience.