### PR TITLE
Test with Ruby 2.5-2.7, cache bundler in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,13 @@
-sudo: false
 language: ruby
+cache: bundler
 rvm:
   - 2.1
   - 2.2
-  - 2.3.0
-  - 2.4.0
+  - 2.3
+  - 2.4
+  - 2.5
+  - 2.6
+  - 2.7
   - jruby-9.2.0.0 # latest stable
   - jruby-head
   - rbx-2


### PR DESCRIPTION
`sudo: false` is deprecated.