### PR TITLE
Fix Ruby 2.7 keyword parameter deprecations

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -62,6 +62,15 @@ Style/Documentation:
     - 'example/upgrade_server.rb'
     - 'lib/tasks/generate_huffman_table.rb'
 
+# Offense count: 3
+# Cop supports --auto-correct.
+# Configuration parameters: EnforcedStyle.
+# SupportedStyles: braces, no_braces, context_dependent
+Style/BracesAroundHashParameters:
+  Exclude:
+    - 'spec/connection_spec.rb'
+    - 'spec/server_spec.rb'
+
 # Offense count: 1
 # Cop supports --auto-correct.
 Style/EmptyCaseCondition:

--- a/lib/http/2/compressor.rb
+++ b/lib/http/2/compressor.rb
@@ -331,7 +331,7 @@ module HTTP2
     class Compressor
       # @param options [Hash] encoding options
       def initialize(**options)
-        @cc = EncodingContext.new(options)
+        @cc = EncodingContext.new(**options)
       end
 
       # Set dynamic table size in EncodingContext
@@ -470,7 +470,7 @@ module HTTP2
     class Decompressor
       # @param options [Hash] decoding options.  Only :table_size is effective.
       def initialize(**options)
-        @cc = EncodingContext.new(options)
+        @cc = EncodingContext.new(**options)
       end
 
       # Set dynamic table size in EncodingContext

--- a/lib/http/2/connection.rb
+++ b/lib/http/2/connection.rb
@@ -76,8 +76,8 @@ module HTTP2
       @local_settings  = DEFAULT_CONNECTION_SETTINGS.merge(settings)
       @remote_settings = SPEC_DEFAULT_CONNECTION_SETTINGS.dup
 
-      @compressor   = Header::Compressor.new(settings)
-      @decompressor = Header::Decompressor.new(settings)
+      @compressor   = Header::Compressor.new(**settings)
+      @decompressor = Header::Decompressor.new(**settings)
 
       @active_stream_count = 0
       @streams = {}
@@ -674,7 +674,7 @@ module HTTP2
     def activate_stream(id: nil, **args)
       connection_error(msg: 'Stream ID already exists') if @streams.key?(id)
 
-      stream = Stream.new({ connection: self, id: id }.merge(args))
+      stream = Stream.new(**{ connection: self, id: id }.merge(args))
 
       # Streams that are in the "open" state, or either of the "half closed"
       # states count toward the maximum number of streams that an endpoint is

--- a/spec/connection_spec.rb
+++ b/spec/connection_spec.rb
@@ -369,7 +369,7 @@ RSpec.describe HTTP2::Connection do
       stream = @conn.new_stream
 
       expect do
-        stream.headers('name' => Float::INFINITY)
+        stream.headers({ 'name' => Float::INFINITY })
       end.to raise_error(CompressionError)
     end
 
@@ -397,10 +397,10 @@ RSpec.describe HTTP2::Connection do
       end
 
       stream = @conn.new_stream
-      stream.headers(':method' => 'get',
-                     ':scheme' => 'http',
-                     ':authority' => 'www.example.org',
-                     ':path'   => '/resource')
+      stream.headers({ ':method' => 'get',
+                       ':scheme' => 'http',
+                       ':authority' => 'www.example.org',
+                       ':path'   => '/resource' })
     end
 
     it 'should generate CONTINUATION if HEADERS is too long' do

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe HTTP2::Server do
 
     @srv.on(:stream) do |stream|
       expect do
-        stream.promise(':method' => 'GET') {}
+        stream.promise({ ':method' => 'GET' }) {}
       end.to_not raise_error
     end
 


### PR DESCRIPTION
This fixes `warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call` and `warning: Passing the keyword argument as the last hash parameter is deprecated` when using Ruby 2.7 (see https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/)