### PR TITLE
update max frame size on receiving SETTINGS frame from peer

### DIFF
--- a/lib/http/2/connection.rb
+++ b/lib/http/2/connection.rb
@@ -539,7 +539,7 @@ module HTTP2
         # Process pending settings we have sent.
         [@pending_settings.shift, :local]
       else
-        connection_error(check) if validate_settings(@remote_role, frame[:payload])
+        connection_error if validate_settings(@remote_role, frame[:payload])
         [frame[:payload], :remote]
       end
 
@@ -593,7 +593,8 @@ module HTTP2
           # nothing to do
 
         when :settings_max_frame_size
-          # nothing to do
+          # update framer max_frame_size
+          @framer.max_frame_size = v
 
           # else # ignore unknown settings
         end

--- a/spec/connection_spec.rb
+++ b/spec/connection_spec.rb
@@ -49,6 +49,22 @@ RSpec.describe HTTP2::Connection do
 
       expect(@conn.remote_settings[:settings_header_table_size]).to eq 256
     end
+    
+    it 'should reflect settings_max_frame_size recevied from perr' do
+      settings = settings_frame
+      settings[:payload] = [[:settings_max_frame_size, 16_385]]
+
+      @conn << f.generate(settings)
+
+      frame = {
+        length: 16_385,
+        type: :data,
+        flags: [:end_stream],
+        stream: 1,
+        payload: 'a' * 16_385,
+      }
+      expect { @conn.send(frame) }.not_to raise_error(CompressionError)
+    end
 
     it 'should send SETTINGS ACK when SETTINGS is received' do
       settings = settings_frame

--- a/spec/connection_spec.rb
+++ b/spec/connection_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe HTTP2::Connection do
       expect(@conn.remote_settings[:settings_header_table_size]).to eq 256
     end
     
-    it 'should reflect settings_max_frame_size recevied from perr' do
+    it 'should reflect settings_max_frame_size recevied from peer' do
       settings = settings_frame
       settings[:payload] = [[:settings_max_frame_size, 16_385]]
 

--- a/spec/connection_spec.rb
+++ b/spec/connection_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe HTTP2::Connection do
 
       expect(@conn.remote_settings[:settings_header_table_size]).to eq 256
     end
-    
+
     it 'should reflect settings_max_frame_size recevied from peer' do
       settings = settings_frame
       settings[:payload] = [[:settings_max_frame_size, 16_385]]


### PR DESCRIPTION
Currently the framer max_frame_size is not being updated as reported in [151](https://github.com/igrigorik/http-2/issues/151).  This PR tries fix that