### PR TITLE
Add mutexes to client examples to avoid race conditions

### DIFF
--- a/example/client.rb
+++ b/example/client.rb
@@ -42,10 +42,13 @@ conn = HTTP2::Client.new
 stream = conn.new_stream
 log = Logger.new(stream.id)
 
+conn_mutex = Mutex.new # Synchronize writing to socket
 conn.on(:frame) do |bytes|
-  # puts "Sending bytes: #{bytes.unpack("H*").first}"
-  sock.print bytes
-  sock.flush
+  conn_mutex.synchronize { # Make sure that only one frame is sent at a time
+    # puts "Sending bytes: #{bytes.unpack("H*").first}"
+    sock.print bytes
+    sock.flush
+  }
 end
 conn.on(:frame_sent) do |frame|
   puts "Sent frame: #{frame.inspect}"

--- a/example/client.rb
+++ b/example/client.rb
@@ -44,11 +44,11 @@ log = Logger.new(stream.id)
 
 conn_mutex = Mutex.new # Synchronize writing to socket
 conn.on(:frame) do |bytes|
-  conn_mutex.synchronize { # Make sure that only one frame is sent at a time
+  conn_mutex.synchronize do # Make sure that only one frame is sent at a time
     # puts "Sending bytes: #{bytes.unpack("H*").first}"
     sock.print bytes
     sock.flush
-  }
+  end
 end
 conn.on(:frame_sent) do |frame|
   puts "Sent frame: #{frame.inspect}"

--- a/example/upgrade_client.rb
+++ b/example/upgrade_client.rb
@@ -23,10 +23,10 @@ end
 
 conn_mutex = Mutex.new # Synchronize writing to socket
 conn.on(:frame) do |bytes|
-  conn_mutex.synchronize { # Make sure that only one frame is sent at a time
+  conn_mutex.synchronize do # Make sure that only one frame is sent at a time
     sock.print bytes
     sock.flush
-  }
+  end
 end
 conn.on(:frame_sent) do |frame|
   puts "Sent frame: #{frame.inspect}"

--- a/example/upgrade_client.rb
+++ b/example/upgrade_client.rb
@@ -21,9 +21,12 @@ def request_header_hash
   end
 end
 
+conn_mutex = Mutex.new # Synchronize writing to socket
 conn.on(:frame) do |bytes|
-  sock.print bytes
-  sock.flush
+  conn_mutex.synchronize { # Make sure that only one frame is sent at a time
+    sock.print bytes
+    sock.flush
+  }
 end
 conn.on(:frame_sent) do |frame|
   puts "Sent frame: #{frame.inspect}"


### PR DESCRIPTION
When streaming a lot of data or opening a lot of streams it is possible that HTTP2::Client#on(:bytes) will call blocks before completion of the previous one.
I suggest to add mutexes to examples to present how to avoid this situation resulting in OpenSSL errors.