### PR TITLE
Support running with --enable=frozen-string-literal

### DIFF
--- a/lib/http/2/huffman.rb
+++ b/lib/http/2/huffman.rb
@@ -30,7 +30,7 @@ module HTTP2
       # @return [String] binary string
       # @raise [CompressionError] when Huffman coded string is malformed
       def decode(buf)
-        emit = ''
+        emit = String.new
         state = 0 # start state
 
         mask = (1 << BITS_AT_ONCE) - 1

--- a/spec/framer_spec.rb
+++ b/spec/framer_spec.rb
@@ -1,3 +1,4 @@
+# frozen-string-literal: false
 require 'helper'
 
 RSpec.describe HTTP2::Framer do

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -1,3 +1,4 @@
+# frozen-string-literal: false
 require './spec/support/deep_dup'
 
 RSpec.configure(&:disable_monkey_patching!)


### PR DESCRIPTION
In apps that run with `--enable=frozen-string-literal` we can get a `FrozenError`.

Using `String.new` instead of `''` fixes that without breaking it for anyone else.

When running the specs frozen strings (`RUBYOPT="--enable=frozen-string-literal" rake`), there were two files that have errors. I added the magic comment: `# frozen-string-literal: false` to those to work both ways.