### PR TITLE
Reduce gem size

### DIFF
--- a/http-2.gemspec
+++ b/http-2.gemspec
@@ -1,6 +1,4 @@
-lib = File.expand_path('./lib', __dir__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'http/2/version'
+require_relative 'lib/http/2/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'http-2'
@@ -13,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
   spec.required_ruby_version = '>=2.1.0'
 
-  spec.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
+  spec.files         = Dir["LICENSE", "README.md", "lib/**/*.rb"]
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']

--- a/lib/http/2/version.rb
+++ b/lib/http/2/version.rb
@@ -1,3 +1,3 @@
 module HTTP2
-  VERSION = '0.11.0'.freeze
+  VERSION = '0.11.1'.freeze
 end


### PR DESCRIPTION
# Summary
The existing gem includes all tracked files from git, many of which are not needed at runtime.  The [current gem version](https://rubygems.org/gems/http-2/versions/0.11.0) is 1.95 MB.  This change reduces the size to 48KB by including only the library files required at runtime.
