### PR TITLE
Add base64 as a dependency for Ruby 3.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source 'https://rubygems.org'
 
+gemspec
 gem 'rake', require: false
 
 group :development do

--- a/http-2.gemspec
+++ b/http-2.gemspec
@@ -11,5 +11,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
   spec.files         = Dir["LICENSE", "README.md", "lib/**/*.rb"]
 
+  spec.add_runtime_dependency 'base64'
+
   spec.required_ruby_version = '>= 2.5'
 end

--- a/spec/compressor_spec.rb
+++ b/spec/compressor_spec.rb
@@ -645,7 +645,6 @@ RSpec.describe HTTP2::Header do
               end
             end
             it 'should emit expected bytes on wire' do
-              puts subject.unpack('H*').first
               expect(subject.unpack('H*').first).to eq ex[:streams][nth][:wire].delete(" \n")
             end
             unless ex[:streams][nth][:has_bad_headers]


### PR DESCRIPTION
Adds base64 as a dependency as required by Ruby 3.4