### PR TITLE
Fix memory leak on persistent connections

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,6 +21,9 @@ Layout/HeredocIndentation:
 Metrics/BlockLength:
   Enabled: false
 
+Metrics/PerceivedComplexity:
+  Enabled: false
+
 Lint/EmptyWhen:
   Enabled: false
 

--- a/lib/http/2/connection.rb
+++ b/lib/http/2/connection.rb
@@ -744,6 +744,8 @@ module HTTP2
       stream = Stream.new(connection: self, id: id, **args)
 
       stream.once(:close) do
+        @streams.delete(id)
+
         # Store a reference to the closed stream, such that we can respond
         # to any in-flight frames while close is registered on both sides.
         # References to such streams will be purged whenever another stream

--- a/lib/http/2/connection.rb
+++ b/lib/http/2/connection.rb
@@ -391,6 +391,13 @@ module HTTP2
                 stream = @streams_recently_closed[frame[:stream]]
                 connection_error(:protocol_error, msg: "sent window update on idle stream") unless stream
                 process_window_update(frame: frame, encode: true)
+              # Endpoints MUST ignore
+              # WINDOW_UPDATE or RST_STREAM frames received in this state (closed), though
+              # endpoints MAY choose to treat frames that arrive a significant
+              # time after sending END_STREAM as a connection error.
+              when :rst_stream
+                stream = @streams_recently_closed[frame[:stream]]
+                connection_error(:protocol_error, msg: "sent window update on idle stream") unless stream
               else
                 # An endpoint that receives an unexpected stream identifier
                 # MUST respond with a connection error of type PROTOCOL_ERROR.

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -205,7 +205,6 @@ RSpec.describe HTTP2::Client do
       it "should emit :altsvc" do
         s = client.new_stream
         s.send headers_frame
-        s.close
 
         frame = nil
         s.on(:altsvc) { |f| frame = f }
@@ -217,7 +216,6 @@ RSpec.describe HTTP2::Client do
       it "should not emit :alt_svc when the frame when contains a origin" do
         s = client.new_stream
         s.send headers_frame
-        s.close
 
         frame = nil
         s.on(:altsvc) { |f| frame = f }
@@ -270,7 +268,6 @@ RSpec.describe HTTP2::Client do
       it "should be ignored" do
         s = client.new_stream
         s.send headers_frame
-        s.close
 
         expect do
           client << set_stream_id(f.generate(orig_frame), s.id)

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -118,8 +118,20 @@ RSpec.describe HTTP2::Server do
       stream.send data_frame
       stream.close
 
+      # WINDOW_UPDATE or RST_STREAM frames can be received in this state
+      # for a short period
       expect do
         srv << f.generate(rst_stream_frame.merge(stream: stream.id))
+      end.to_not raise_error
+
+      expect do
+        srv << f.generate(window_update_frame.merge(stream: stream.id))
+      end.to_not raise_error
+
+      # PRIORITY frames can be sent on closed streams to prioritize
+      # streams that are dependent on the closed stream.
+      expect do
+        srv << f.generate(priority_frame.merge(stream: stream.id))
       end.to_not raise_error
     end
   end


### PR DESCRIPTION
I noticed a memory leak in my Rails app. The app uses the `searchkick` gem for searching using elasticsearch. That in turn uses the `faraday` gem. I had opted to use `httpx` via it's faraday adapter so I could take advantage of a persistent connection to the elasticsearch server.

But recently I started noticing a memory leak in my application. After doing some investigative work on some heap dumps, I started to zero in on httpx, http-2-next, and now after a recent update, http-2.

It is at this point that I should stress: _I have no idea what I'm doing_. I've made a change here. It makes sense to me, as someone who knows _literally nothing_ about what is required to build or design a working http/2 client. But it seemed like it could be the source of my leak, so I decided to patch it and run it in production on a Friday. 🎉

I'm now about 4 hours in to my inadvisable experiment, and astonishingly nothing seems to have broken. And the memory profile is now flat again!

I have no notion that this PR is worth merging in as is. But I wanted to open it just to say, that I'm _fairly_ confident that there exists a memory leak in the `HTTP2::Connection` class as it is right now. And I'm reasonably confident that this change (however incorrect it is in other ways) seems to fix it, and not immediately cause other problems.

Thanks for your work on this gem. I hope this PR helps in some way, even if it isn't by providing mergable code.