### PR TITLE
Buffer encoding issues

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -31,7 +31,7 @@ Metrics/CyclomaticComplexity:
 # Offense count: 29
 # Configuration parameters: CountComments.
 Metrics/MethodLength:
-  Max: 134
+  Enabled: false
 
 # Offense count: 1
 # Configuration parameters: CountKeywordArgs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 1.1.1
+
+### Bugfixes
+
+* frame buffer was accidentally changing encoding before header packing, which raise invalid compatible encoding errors, due to usage of "String#". this was fixed by using internal `append_str´, which does not touch encoding, and calling `String.force_encoding` in case the buffer is a mutable string passed by the user.
+* dup PING frame payload passed by the user; while not really resulting in invalid encoding, the change of the input string could surprise the caller, since this would be expected to be stored somewhere so the peer PING frame can be matched on receive.
+
+
+### Improvements
+
+Simplified `String#transition`, making sure it only does state machine transitions (the rest is handled outside of it).
+
 ## 1.1.0
 
 Several changes which improved performance for the common cases. A few highlights:

--- a/lib/http/2/connection.rb
+++ b/lib/http/2/connection.rb
@@ -403,8 +403,9 @@ module HTTP2
               # endpoints MAY choose to treat frames that arrive a significant
               # time after sending END_STREAM as a connection error.
               when :rst_stream
-                stream = @streams_recently_closed[stream_id]
-                connection_error(:protocol_error, msg: "sent window update on idle stream") unless stream
+                unless @streams_recently_closed.key?(stream_id)
+                  connection_error(:protocol_error, msg: "sent window update on idle stream")
+                end
               else
                 # An endpoint that receives an unexpected stream identifier
                 # MUST respond with a connection error of type PROTOCOL_ERROR.

--- a/lib/http/2/framer.rb
+++ b/lib/http/2/framer.rb
@@ -271,7 +271,7 @@ module HTTP2
         append_str(bytes, frame[:payload])
 
       when :ping
-        bytes = frame[:payload]
+        bytes = frame[:payload].b
         raise CompressionError, "Invalid payload size (#{bytes.size} != 8 bytes)" if bytes.bytesize != 8
 
         length = 8

--- a/lib/http/2/framer.rb
+++ b/lib/http/2/framer.rb
@@ -148,9 +148,12 @@ module HTTP2
 
       header = buffer
 
+      # make sure the buffer is binary and unfrozen
       if buffer.frozen?
         header = String.new("", encoding: Encoding::BINARY, capacity: buffer.bytesize + 9) # header length
-        header << buffer
+        append_str(header, buffer)
+      else
+        header.force_encoding(Encoding::BINARY)
       end
 
       pack([
@@ -340,6 +343,13 @@ module HTTP2
 
         if padlen <= 0 || padlen > 256 || padlen + length > @remote_max_frame_size
           raise CompressionError, "Invalid padding #{padlen}"
+        end
+
+        # make sure the buffer is binary and unfrozen
+        if bytes.frozen?
+          bytes = bytes.b
+        else
+          bytes.force_encoding(Encoding::BINARY)
         end
 
         length += padlen

--- a/lib/http/2/stream.rb
+++ b/lib/http/2/stream.rb
@@ -405,19 +405,19 @@ module HTTP2
       # WINDOW_UPDATE on a stream in this state MUST be treated as a
       # connection error (Section 5.4.1) of type PROTOCOL_ERROR.
       when :reserved_local
-        @state = if sending
-                   case frame[:type]
-                   when :headers     then event(:half_closed_remote)
-                   when :rst_stream  then event(:local_rst)
-                   else stream_error
-                   end
-                 else
-                   case frame[:type]
-                   when :rst_stream then event(:remote_rst)
-                   when :priority, :window_update then @state
-                   else stream_error
-                   end
-                 end
+        if sending
+          case frame[:type]
+          when :headers     then event(:half_closed_remote)
+          when :rst_stream  then event(:local_rst)
+          else stream_error
+          end
+        else
+          case frame[:type]
+          when :rst_stream then event(:remote_rst)
+          when :priority, :window_update
+          else stream_error
+          end
+        end
 
       # A stream in the "reserved (remote)" state has been reserved by a
       # remote peer.
@@ -434,19 +434,19 @@ module HTTP2
       # PRIORITY on a stream in this state MUST be treated as a connection
       # error (Section 5.4.1) of type PROTOCOL_ERROR.
       when :reserved_remote
-        @state = if sending
-                   case frame[:type]
-                   when :rst_stream then event(:local_rst)
-                   when :priority, :window_update then @state
-                   else stream_error
-                   end
-                 else
-                   case frame[:type]
-                   when :headers then event(:half_closed_local)
-                   when :rst_stream then event(:remote_rst)
-                   else stream_error
-                   end
-                 end
+        if sending
+          case frame[:type]
+          when :rst_stream then event(:local_rst)
+          when :priority, :window_update
+          else stream_error
+          end
+        else
+          case frame[:type]
+          when :headers then event(:half_closed_local)
+          when :rst_stream then event(:remote_rst)
+          else stream_error
+          end
+        end
 
       # A stream in the "open" state may be used by both peers to send
       # frames of any type.  In this state, sending peers observe

--- a/lib/http/2/version.rb
+++ b/lib/http/2/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module HTTP2
-  VERSION = "1.1.0"
+  VERSION = "1.1.1"
 end

--- a/spec/stream_spec.rb
+++ b/spec/stream_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe HTTP2::Stream do
       end
 
       it "should raise error if sending invalid frames" do
-        frame_types.reject { |frame| %i[headers rst_stream].include?(frame[:type]) }.each do |type|
+        frame_types.reject { |frame| %i[headers rst_stream priority].include?(frame[:type]) }.each do |type|
           expect { stream.dup.send type }.to raise_error InternalError
         end
       end
@@ -114,7 +114,7 @@ RSpec.describe HTTP2::Stream do
       end
 
       it "should raise error on receipt of invalid frames" do
-        frame_types.reject { |frame| %i[headers rst_stream].include?(frame[:type]) }.each do |type|
+        frame_types.reject { |frame| %i[headers rst_stream priority].include?(frame[:type]) }.each do |type|
           expect { stream.dup.receive type }.to raise_error InternalError
         end
       end


### PR DESCRIPTION
Contains fixes for some string encoding issues reported [here](https://github.com/HoneyryderChuck/httpx/issues/83) and [here](https://gitlab.com/os85/httpx/-/issues/345).

Releases a new patch version (1.1.1)