### PR TITLE
ignore ping frame when connection is closed

### DIFF
--- a/example/server.rb
+++ b/example/server.rb
@@ -62,10 +62,7 @@ loop do
   end
 
   conn.on(:goaway) do
-    Thread.start do
-      sleep(1)
-      sock.close
-    end
+    sock.close
   end
 
   conn.on(:stream) do |stream|

--- a/lib/http/2/connection.rb
+++ b/lib/http/2/connection.rb
@@ -527,8 +527,6 @@ module HTTP2
         when :goaway
           #  6.8. GOAWAY
           # An endpoint MAY send multiple GOAWAY frames if circumstances change.
-        when :ping
-          ping_management(frame)
         else
           connection_error if (Process.clock_gettime(Process::CLOCK_MONOTONIC) - @closed_since) > 15
         end

--- a/sig/framer.rbs
+++ b/sig/framer.rbs
@@ -34,6 +34,7 @@ module HTTP2
 
     @local_max_frame_size: Integer
     @remote_max_frame_size: Integer
+    @streams: Hash[Integer, Stream]
 
     attr_accessor local_max_frame_size: Integer
 
@@ -47,11 +48,13 @@ module HTTP2
 
     def generate: (frame) -> String
 
-    def parse: (String) -> frame?
+    def parse: (String buf) -> frame?
 
     private
 
     def initialize: (?Integer local_max_frame_size, ?Integer remote_max_frame_size) -> untyped
+
+    def decode_frame: (String buf) -> frame?
 
     def pack_error: (Integer | Symbol error, buffer: String) -> String
 

--- a/spec/shared_examples/connection.rb
+++ b/spec/shared_examples/connection.rb
@@ -135,6 +135,16 @@ RSpec.shared_examples "a connection" do
       expect(pong).to eq "12345678"
     end
 
+    it "should not fire callback on PONG if connection is closed" do
+      conn << f.generate(settings_frame)
+      conn << f.generate(goaway_frame)
+
+      pong = nil
+      conn.ping("12345678") { |d| pong = d }
+      conn << f.generate(pong_frame)
+      expect(pong).to be_nil
+    end
+
     it "should fire callback on receipt of GOAWAY" do
       last_stream, payload, error = nil
       conn << f.generate(settings_frame)


### PR DESCRIPTION
while it's valid to process ping frames after sending/receiving goaway frames, preparing an AC frame may inadvertedly put bytes on the user buffer, thereby signaling that there's something to write back instead of terminating the connection,\

@igrigorik @mullermp would like to ask you guidance on this one. The RFC is not specific on what to do when receiving a PING frame **after** receiving a GOAWAY frame with stream id 0. I found at least one instance of a server which does exactly that, which led to some corruption on a long lived client connection, and while I can theoretically work around it on the client side in order to wipe out the buffer when processing a ping ack frame on a closed connection, that seems to be redundant and something the parser should do for me.