### PR TITLE
Fix bytesplice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.1
+
+* fix: encode the string to binary when using `String#bytesplice` (if the string is UTF-8 and the range would split multibyte characters, bytesplicing raises an error).
+
 ## 1.2.0
 
 ### Improvements

--- a/lib/http/2/connection.rb
+++ b/lib/http/2/connection.rb
@@ -399,7 +399,6 @@ module HTTP2
                 unless @streams_recently_closed.key?(stream_id)
                   connection_error(:protocol_error, msg: "sent window update on idle stream")
                 end
-                stream = @streams_recently_closed[stream_id]
                 process_window_update(frame: frame, encode: true)
               # Endpoints MUST ignore
               # WINDOW_UPDATE or RST_STREAM frames received in this state (closed), though

--- a/lib/http/2/extensions.rb
+++ b/lib/http/2/extensions.rb
@@ -26,9 +26,16 @@ module HTTP2
       def read_str(str, n)
         return "".b if n == 0
 
+        enc = str.encoding
+
+        if enc != Encoding::BINARY
+          str = str.dup if str.frozen?
+          str.force_encoding(Encoding::BINARY)
+        end
+
         chunk = str.byteslice(0, n)
         str.bytesplice(0, chunk.length, "")
-        chunk
+        chunk.force_encoding(Encoding::BINARY)
       end
     else
       def read_str(str, n)
@@ -37,7 +44,7 @@ module HTTP2
         chunk = str.byteslice(0, n)
         remaining = str.byteslice(n, str.size - n)
         remaining ? str.replace(remaining) : str.clear
-        chunk
+        chunk.force_encoding(Encoding::BINARY)
       end
     end
 

--- a/lib/http/2/version.rb
+++ b/lib/http/2/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module HTTP2
-  VERSION = "1.2.0"
+  VERSION = "1.2.1"
 end


### PR DESCRIPTION
fix String#bytesplice usage, which in order to be able to cut UTF-8 characters, requires the string to be encoded as binary, otherwise it'll raise a range error.

most of the strings passed to #read_str come from downstream usage of itself, so there are more chances of reducing string creation by returning binary strings.