### PR TITLE
Drain in-flight streams after a graceful GOAWAY

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,15 @@ Events emitted by the connection object:
   </tr>
 </table>
 
+Connection shutdown happens in two steps. Once a GOAWAY frame is sent or
+received, no new streams may be opened: `closed?` turns true and `new_stream`
+raises `ConnectionClosed` — new work belongs on a new connection. After a
+graceful GOAWAY (`:no_error`), streams the peer may still complete keep
+running: `closing?` distinguishes this draining state, in which the connection
+keeps processing frames — including connection-level flow control — until the
+last tracked stream closes. Streams the GOAWAY refused (id above its
+last-stream-id) are reported via the `:goaway` event, so their callers can
+retry them on a fresh connection.
 
 ### Stream lifecycle management
 

--- a/lib/http/2/connection.rb
+++ b/lib/http/2/connection.rb
@@ -56,7 +56,8 @@ module HTTP2
     include Error
     include BufferUtils
 
-    # Connection state (:new, :closed).
+    # Connection state (:waiting_magic, :waiting_connection_preface,
+    # :connected, :closing, :closed).
     attr_reader :state
 
     # Size of current connection flow control window (by default, set to
@@ -113,8 +114,15 @@ module HTTP2
       @send_buffer = FrameBuffer.new
     end
 
+    # No new streams may be opened (a GOAWAY was sent or received).
     def closed?
-      @state == :closed
+      @state == :closed || @state == :closing
+    end
+
+    # Graceful GOAWAY received: tracked streams may still complete,
+    # but no new ones can be opened.
+    def closing?
+      @state == :closing
     end
 
     # Allocates new stream for current connection.
@@ -123,7 +131,7 @@ module HTTP2
     # @param window [Integer]
     # @param parent [Stream]
     def new_stream(**args)
-      raise ConnectionClosed if @state == :closed
+      raise ConnectionClosed if closed?
       raise StreamLimitExceeded if @active_stream_count >= @remote_settings[:settings_max_concurrent_streams]
 
       connection_error(:protocol_error, msg: "id is smaller than previous") if @stream_id < @last_stream_id
@@ -158,8 +166,7 @@ module HTTP2
     def goaway(error = :no_error, payload = nil)
       send(type: :goaway, stream: 0, last_stream: @last_stream_id,
            error: error, payload: payload)
-      @state = :closed
-      @closed_since = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      close!
     end
 
     # Sends a WINDOW_UPDATE frame to the peer.
@@ -295,12 +302,11 @@ module HTTP2
             # PUSH_PROMISE and CONTINUATION frames MUST be minimally
             # processed to ensure a consistent compression state
             decode_headers(frame)
-            # A GOAWAY moves the connection to :closed, but streams the peer
-            # promised to finish (id <= last_stream_id, already in @streams) can
-            # still complete (RFC 9113 Section 6.8). Only discard HEADERS that
-            # would open a NEW stream; a known stream's response must be
-            # delivered (its DATA frames already are - see the branch below).
-            return if @state == :closed && stream_id > @last_stream_id
+            # After a GOAWAY, HEADERS may only complete a tracked stream at
+            # or below the highest id seen (Section 6.8); anything else is
+            # discarded - decoded above, so the compression state is intact.
+            # Skip only this frame: later ones may serve completing streams.
+            next if closed? && (stream_id > @last_stream_id || !@streams.key?(stream_id))
 
             stream = @streams[stream_id]
             if stream.nil?
@@ -328,7 +334,7 @@ module HTTP2
             end
 
             decode_headers(frame)
-            return if @state == :closed
+            next if closed?
 
             # PUSH_PROMISE frames MUST be associated with an existing, peer-
             # initiated stream... A receiver MUST treat the receipt of a
@@ -385,6 +391,10 @@ module HTTP2
               # group of dependent streams by altering the priority of an
               # unused or closed parent stream.
               when :priority
+                # The stream already existed and closed: reprioritizing a
+                # closed parent is a no-op here - do not resurrect it.
+                next if stream_id <= @last_stream_id
+
                 stream = activate_stream(
                   id: stream_id,
                   weight: frame[:weight] || DEFAULT_WEIGHT,
@@ -500,7 +510,7 @@ module HTTP2
         @state = :connected
         connection_settings(frame)
 
-      when :connected
+      when :connected, :closing
         case frame_type
         when :settings
           # @type var frame: settings_frame
@@ -515,8 +525,13 @@ module HTTP2
           # Receivers of a GOAWAY frame MUST NOT open additional streams on
           # the connection, although a new connection can be established
           # for new streams.
-          @state = :closed
-          @closed_since = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          if frame[:error] == :no_error && !@streams.empty?
+            # A graceful GOAWAY lets tracked streams complete before the
+            # connection closes (Section 6.8).
+            @state = :closing
+          else
+            close!
+          end
           emit(:goaway, frame[:last_stream], frame[:error], frame[:payload])
         when :altsvc
           # @type var frame: altsvc_frame
@@ -786,6 +801,8 @@ module HTTP2
       stream.once(:close) do
         @streams.delete(id)
 
+        close! if @state == :closing && @streams.empty?
+
         # Store a reference to the closed stream, such that we can respond
         # to any in-flight frames while close is registered on both sides.
         # References to such streams will be purged whenever another stream
@@ -814,6 +831,11 @@ module HTTP2
 
       stream.on(:frame, &method(:send))
       @streams[id] = stream
+    end
+
+    def close!
+      @state = :closed
+      @closed_since = Process.clock_gettime(Process::CLOCK_MONOTONIC)
     end
 
     def verify_stream_order(id)

--- a/lib/http/2/connection.rb
+++ b/lib/http/2/connection.rb
@@ -391,9 +391,11 @@ module HTTP2
               # group of dependent streams by altering the priority of an
               # unused or closed parent stream.
               when :priority
-                # The stream already existed and closed: reprioritizing a
-                # closed parent is a no-op here - do not resurrect it.
-                next if stream_id <= @last_stream_id
+                # After a GOAWAY, a PRIORITY for a stream already used and
+                # closed must not resurrect it: reprioritizing a closed
+                # parent is a no-op here, and a phantom stream would hold
+                # the draining connection open.
+                next if closed? && stream_id <= @last_stream_id
 
                 stream = activate_stream(
                   id: stream_id,
@@ -801,6 +803,9 @@ module HTTP2
       stream.once(:close) do
         @streams.delete(id)
 
+        # A graceful GOAWAY leaves the connection :closing until the
+        # tracked streams complete (Section 6.8); the last one to close
+        # moves it to its terminal state.
         close! if @state == :closing && @streams.empty?
 
         # Store a reference to the closed stream, such that we can respond

--- a/lib/http/2/connection.rb
+++ b/lib/http/2/connection.rb
@@ -386,10 +386,9 @@ module HTTP2
               end
             else
               case frame_type
-              # The PRIORITY frame can be sent for a stream in the "idle" or
-              # "closed" state. This allows for the reprioritization of a
-              # group of dependent streams by altering the priority of an
-              # unused or closed parent stream.
+              # Priority signaling is deprecated (RFC 9113 Section 5.3.2), but
+              # a PRIORITY frame may still name a stream id not opened yet:
+              # activate it, so the priority sticks if the stream opens.
               when :priority
                 # After a GOAWAY, a PRIORITY for a stream already used and
                 # closed must not resurrect it: reprioritizing a closed

--- a/lib/http/2/error.rb
+++ b/lib/http/2/error.rb
@@ -53,7 +53,7 @@ module HTTP2
     # Raised if stream has been closed and new frames cannot be sent.
     class StreamClosed < Error; end
 
-    # Raised if connection has been closed (or draining) and new stream
+    # Raised if connection has been closed (or closing) and new stream
     # cannot be opened.
     class ConnectionClosed < Error; end
 

--- a/sig/connection.rbs
+++ b/sig/connection.rbs
@@ -59,6 +59,10 @@ module HTTP2
 
     def closed?: () -> bool
 
+    def closing?: () -> bool
+
+    def close!: () -> void
+
     def new_stream: (**untyped) -> Stream
 
     def ping: (String) -> void

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -353,19 +353,6 @@ RSpec.describe HTTP2::Client do
       client << f.generate(headers_frame.merge(payload: Compressor.new.encode(RESPONSE_HEADERS)))
       expect(client).to be_closed
     end
-
-    it "should not resurrect a closed stream on a late PRIORITY" do
-      stream = client.new_stream
-      stream.send headers_frame
-      stream.close
-
-      opened = false
-      client.on(:stream) { opened = true }
-      client << f.generate(priority_frame.merge(stream: stream.id))
-
-      expect(opened).to be(false)
-      expect(client.active_stream_count).to eq 0
-    end
   end
 
   context "graceful shutdown (GOAWAY)" do
@@ -398,20 +385,37 @@ RSpec.describe HTTP2::Client do
       expect(acks).to eq(%i[settings ping])
     end
 
-    it "should still deliver an in-flight stream's response after a graceful GOAWAY" do
-      stream = client.new_stream
-      stream.send headers_frame
+    it "should deliver in-flight streams' responses and discard untracked ones' while closing" do
+      finished = client.new_stream
+      finished.send headers_frame
+      finished.close # locally reset: no longer tracked
+
+      survivor = client.new_stream
+      survivor.send headers_frame.merge(stream: survivor.id)
 
       received = nil
-      stream.on(:headers) { |headers| received = headers }
+      survivor.on(:headers) { |headers| received = headers }
 
-      client << f.generate(goaway_frame)
-      client << f.generate(headers_frame.merge(payload: Compressor.new.encode(RESPONSE_HEADERS)))
+      client << f.generate(goaway_frame.merge(last_stream: survivor.id))
+      expect(client).to be_closing
+
+      # One read, two responses: HEADERS racing the local reset must not
+      # kill the closing connection, and discarding them (decoded, so the
+      # compression state stays intact) must not defer the survivor's.
+      compressor = Compressor.new
+      reset_response = f.generate(headers_frame.merge(payload: compressor.encode(RESPONSE_HEADERS)))
+      survivor_response = f.generate(headers_frame.merge(stream: survivor.id,
+                                                         payload: compressor.encode(RESPONSE_HEADERS)))
+      client << (reset_response + survivor_response)
 
       expect(received).to eq(RESPONSE_HEADERS)
+      expect(client).to be_closing
+
+      client << f.generate(rst_stream_frame.merge(stream: survivor.id))
+      expect(client).to be_closed
     end
 
-    it "should discard HEADERS for a stream it no longer tracks while closing" do
+    it "should not resurrect a finished stream on a late PRIORITY while closing" do
       finished = client.new_stream
       finished.send headers_frame
       finished.close # locally reset: no longer tracked
@@ -420,13 +424,16 @@ RSpec.describe HTTP2::Client do
       survivor.send headers_frame.merge(stream: survivor.id)
 
       client << f.generate(goaway_frame.merge(last_stream: survivor.id))
-
-      # Response HEADERS racing the local reset must not kill the
-      # closing connection.
-      client << f.generate(headers_frame.merge(payload: Compressor.new.encode(RESPONSE_HEADERS)))
       expect(client).to be_closing
 
+      opened = false
+      client.on(:stream) { opened = true }
+      client << f.generate(priority_frame.merge(stream: finished.id))
+      expect(opened).to be(false)
+
+      # A resurrected phantom stream would also hold the drain open.
       client << f.generate(rst_stream_frame.merge(stream: survivor.id))
+      expect(client).not_to be_closing
       expect(client).to be_closed
     end
 
@@ -475,30 +482,6 @@ RSpec.describe HTTP2::Client do
       # promised one holds the drain open.
       client << f.generate(rst_stream_frame.merge(stream: promised.id))
       expect(client).to be_closed
-    end
-
-    it "should keep processing frames that follow a discarded HEADERS in the same read" do
-      finished = client.new_stream
-      finished.send headers_frame
-      finished.close # locally reset: no longer tracked
-
-      survivor = client.new_stream
-      survivor.send headers_frame.merge(stream: survivor.id)
-
-      received = nil
-      survivor.on(:headers) { |headers| received = headers }
-
-      client << f.generate(goaway_frame.merge(last_stream: survivor.id))
-
-      # One read, two responses: discarding the first (reset stream) must
-      # not defer the survivor's.
-      compressor = Compressor.new
-      reset_response = f.generate(headers_frame.merge(payload: compressor.encode(RESPONSE_HEADERS)))
-      survivor_response = f.generate(headers_frame.merge(stream: survivor.id,
-                                                         payload: compressor.encode(RESPONSE_HEADERS)))
-      client << (reset_response + survivor_response)
-
-      expect(received).to eq(RESPONSE_HEADERS)
     end
 
     it "should report closed when only idle or reserved streams remain" do

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -339,6 +339,207 @@ RSpec.describe HTTP2::Client do
       expect(opened).to be(false)
       expect(client.active_stream_count).to eq 0
     end
+
+    it "should drop response headers for a stream it no longer tracks once closed" do
+      stream = client.new_stream
+      stream.send headers_frame
+      stream.close # locally reset: no longer tracked
+
+      client << f.generate(goaway_frame) # nothing left to drain: :closed
+      expect(client).to be_closed
+
+      # Response HEADERS racing the local reset must not kill the closed
+      # connection.
+      client << f.generate(headers_frame.merge(payload: Compressor.new.encode(RESPONSE_HEADERS)))
+      expect(client).to be_closed
+    end
+
+    it "should not resurrect a closed stream on a late PRIORITY" do
+      stream = client.new_stream
+      stream.send headers_frame
+      stream.close
+
+      opened = false
+      client.on(:stream) { opened = true }
+      client << f.generate(priority_frame.merge(stream: stream.id))
+
+      expect(opened).to be(false)
+      expect(client.active_stream_count).to eq 0
+    end
+  end
+
+  context "graceful shutdown (GOAWAY)" do
+    it "should keep the connection operating for in-flight streams after a graceful GOAWAY" do
+      stream = client.new_stream
+      stream.send headers_frame
+
+      client << f.generate(goaway_frame)
+      expect(client).to be_closing
+      # closed? reports "no new work" from GOAWAY receipt on, as it always did.
+      expect(client).to be_closed
+
+      # Connection-level flow control must keep working while closing.
+      client << f.generate(window_update_frame.merge(stream: 0, increment: 1000))
+      expect(client.remote_window).to eq DEFAULT_FLOW_WINDOW + 1000
+    end
+
+    it "should ack SETTINGS and answer PING while closing" do
+      stream = client.new_stream
+      stream.send headers_frame
+
+      client << f.generate(goaway_frame)
+
+      acks = []
+      client.on(:frame_sent) { |frame| acks << frame[:type] if frame[:flags].anybits?(ACK) }
+
+      client << f.generate(settings_frame)
+      client << f.generate(ping_frame)
+
+      expect(acks).to eq(%i[settings ping])
+    end
+
+    it "should still deliver an in-flight stream's response after a graceful GOAWAY" do
+      stream = client.new_stream
+      stream.send headers_frame
+
+      received = nil
+      stream.on(:headers) { |headers| received = headers }
+
+      client << f.generate(goaway_frame)
+      client << f.generate(headers_frame.merge(payload: Compressor.new.encode(RESPONSE_HEADERS)))
+
+      expect(received).to eq(RESPONSE_HEADERS)
+    end
+
+    it "should discard HEADERS for a stream it no longer tracks while closing" do
+      finished = client.new_stream
+      finished.send headers_frame
+      finished.close # locally reset: no longer tracked
+
+      survivor = client.new_stream
+      survivor.send headers_frame.merge(stream: survivor.id)
+
+      client << f.generate(goaway_frame.merge(last_stream: survivor.id))
+
+      # Response HEADERS racing the local reset must not kill the
+      # closing connection.
+      client << f.generate(headers_frame.merge(payload: Compressor.new.encode(RESPONSE_HEADERS)))
+      expect(client).to be_closing
+
+      client << f.generate(rst_stream_frame.merge(stream: survivor.id))
+      expect(client).to be_closed
+    end
+
+    it "should not deliver HEADERS that would open a new stream while closing" do
+      client.new_stream.send headers_frame
+
+      opened = false
+      client.on(:stream) { opened = true }
+
+      client << f.generate(goaway_frame)
+      client << f.generate(headers_frame.merge(stream: 5, payload: Compressor.new.encode(RESPONSE_HEADERS)))
+
+      expect(opened).to be(false)
+      expect(client.active_stream_count).to eq 1
+    end
+
+    it "should not let HEADERS on an unpromised push stream open it while closing" do
+      stream = client.new_stream
+      stream.send headers_frame
+      second = client.new_stream
+      second.send headers_frame.merge(stream: second.id)
+
+      client << f.generate(goaway_frame.merge(last_stream: second.id))
+
+      opened = false
+      client.on(:stream) { opened = true }
+      client << f.generate(headers_frame.merge(stream: 2, payload: Compressor.new.encode(RESPONSE_HEADERS)))
+
+      expect(opened).to be(false)
+
+      client << f.generate(rst_stream_frame.merge(stream: stream.id))
+      client << f.generate(rst_stream_frame.merge(stream: second.id))
+      expect(client).to be_closed
+    end
+
+    it "should not wait for streams the GOAWAY refused" do
+      promised = client.new_stream
+      promised.send headers_frame
+      refused = client.new_stream
+      refused.send headers_frame.merge(stream: refused.id)
+
+      client << f.generate(goaway_frame.merge(last_stream: promised.id))
+      expect(client).to be_closing
+
+      # The refused stream (above last_stream_id) never completes; only the
+      # promised one holds the drain open.
+      client << f.generate(rst_stream_frame.merge(stream: promised.id))
+      expect(client).to be_closed
+    end
+
+    it "should keep processing frames that follow a discarded HEADERS in the same read" do
+      finished = client.new_stream
+      finished.send headers_frame
+      finished.close # locally reset: no longer tracked
+
+      survivor = client.new_stream
+      survivor.send headers_frame.merge(stream: survivor.id)
+
+      received = nil
+      survivor.on(:headers) { |headers| received = headers }
+
+      client << f.generate(goaway_frame.merge(last_stream: survivor.id))
+
+      # One read, two responses: discarding the first (reset stream) must
+      # not defer the survivor's.
+      compressor = Compressor.new
+      reset_response = f.generate(headers_frame.merge(payload: compressor.encode(RESPONSE_HEADERS)))
+      survivor_response = f.generate(headers_frame.merge(stream: survivor.id,
+                                                         payload: compressor.encode(RESPONSE_HEADERS)))
+      client << (reset_response + survivor_response)
+
+      expect(received).to eq(RESPONSE_HEADERS)
+    end
+
+    it "should report closed when only idle or reserved streams remain" do
+      client << f.generate(priority_frame.merge(stream: 2)) # idle, never completes
+
+      client << f.generate(goaway_frame)
+
+      expect(client).to be_closed
+    end
+
+    it "should not wait for an undelivered push promise" do
+      stream = client.new_stream
+      stream.send headers_frame
+      client << f.generate(push_promise_frame) # reserves stream 2, never delivered
+
+      client << f.generate(goaway_frame)
+      expect(client).to be_closing
+
+      client << f.generate(rst_stream_frame.merge(stream: stream.id))
+      expect(client).to be_closed
+    end
+
+    it "should close once the last in-flight stream finishes" do
+      stream = client.new_stream
+      stream.send headers_frame
+
+      client << f.generate(goaway_frame)
+      client << f.generate(rst_stream_frame.merge(stream: stream.id))
+
+      expect(client).not_to be_closing
+      expect(client).to be_closed
+    end
+
+    it "should close when a subsequent GOAWAY reports an error while closing" do
+      client.new_stream.send headers_frame
+      client << f.generate(goaway_frame)
+      expect(client).to be_closing
+
+      client << f.generate(goaway_frame.merge(error: :internal_error))
+      expect(client).to be_closed
+    end
   end
 
   context "framing" do

--- a/spec/shared_examples/connection.rb
+++ b/spec/shared_examples/connection.rb
@@ -165,6 +165,32 @@ RSpec.shared_examples "a connection" do
       expect { conn.new_stream }.to raise_error(ConnectionClosed)
     end
 
+    it "should drain in-flight streams after receiving a graceful GOAWAY" do
+      stream = connected_conn.new_stream
+      stream.send headers_frame
+
+      connected_conn << f.generate(goaway_frame)
+      expect(connected_conn).to be_closing
+
+      # Connection-level frames keep being processed while closing.
+      connected_conn << f.generate(window_update_frame.merge(stream: 0, increment: 1000))
+      expect(connected_conn.remote_window).to eq DEFAULT_FLOW_WINDOW + 1000
+
+      expect { connected_conn.new_stream }.to raise_error(ConnectionClosed)
+
+      stream.close
+      expect(connected_conn).not_to be_closing
+      expect(connected_conn).to be_closed
+    end
+
+    it "should close immediately on GOAWAY with an error code" do
+      connected_conn.new_stream
+
+      connected_conn << f.generate(goaway_frame.merge(error: :internal_error))
+
+      expect(connected_conn).to be_closed
+    end
+
     it "should not raise error when receiving connection management frames immediately after emitting goaway" do
       conn.goaway
       expect(conn).to be_closed

--- a/spec/shared_examples/connection.rb
+++ b/spec/shared_examples/connection.rb
@@ -176,6 +176,12 @@ RSpec.shared_examples "a connection" do
       connected_conn << f.generate(window_update_frame.merge(stream: 0, increment: 1000))
       expect(connected_conn.remote_window).to eq DEFAULT_FLOW_WINDOW + 1000
 
+      # ... and so do frames for the streams being drained.
+      received = nil
+      stream.on(:data) { |data| received = data }
+      connected_conn << f.generate(data_frame.merge(stream: stream.id))
+      expect(received).to eq "text"
+
       expect { connected_conn.new_stream }.to raise_error(ConnectionClosed)
 
       stream.close


### PR DESCRIPTION
On a graceful GOAWAY the connection moved straight to `:closed`, where connection-level WINDOW_UPDATE and SETTINGS are ignored — and escalate to a connection error 15s later (#140) — while the peer keeps completing streams at or below last_stream_id (RFC 9113 Section 6.8). In-flight uploads stall on the frozen connection window, and drains longer than 15s kill every promised stream.

A graceful GOAWAY received while streams are tracked now enters `:closing`: connection-level frames are processed as usual, tracked streams run to completion, and the connection moves to `:closed` when the last one ends (or immediately on an error GOAWAY). HEADERS that would open a new stream and PUSH_PROMISE are discarded (after HPACK decoding, keeping compression state consistent), and `new_stream` keeps raising ConnectionClosed.

`closed?` now answers "does this connection accept new work?" — true from GOAWAY receipt on, exactly when it turned true before this change; `closing?` distinguishes a still-draining connection. Streams the GOAWAY refused (or that never started) hold nothing open: callers keep tracking refusals via the `:goaway` event and retry on a new connection.

After a GOAWAY, a PRIORITY frame for an already-used stream id no longer resurrects a phantom stream (previously it re-activated the id and emitted `:stream` with no HEADERS behind it — while draining, such a phantom would also hold the connection in `:closing` forever). Live-connection PRIORITY handling is unchanged.

Draining only affects frames the application feeds via `#receive` — nothing is buffered behind its back (the #184 concern). Subsumes the #192 HEADERS loss while draining; #192 still applies to an already-closed connection.

Validated end-to-end against golang.org/x/net/http2 graceful shutdown (h2c): session streams keep serving mid-drain, a 3 MB upload crosses the connection window while :closing, and post-GOAWAY stream opens fail fast for retry on a fresh connection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
